### PR TITLE
Astra DB, bring all astrapy imports outside of classes in the astradb utils

### DIFF
--- a/libs/astradb/langchain_astradb/utils/astradb.py
+++ b/libs/astradb/langchain_astradb/utils/astradb.py
@@ -7,7 +7,7 @@ from enum import Enum
 from typing import Awaitable, Optional, Union
 
 import langchain_core
-from astrapy.db import AstraDB, AsyncAstraDB
+from astrapy.db import AstraDB, AstraDBCollection, AsyncAstraDB, AsyncAstraDBCollection
 
 
 class SetupMode(Enum):
@@ -90,8 +90,6 @@ class _AstraDBCollectionEnvironment(_AstraDBEnvironment):
         embedding_dimension: Union[int, Awaitable[int], None] = None,
         metric: Optional[str] = None,
     ) -> None:
-        from astrapy.db import AstraDBCollection, AsyncAstraDBCollection
-
         super().__init__(
             token, api_endpoint, astra_db_client, async_astra_db_client, namespace
         )


### PR DESCRIPTION
Moving https://github.com/langchain-ai/langchain/pull/18132 over to this repo.

**Note** (for the temporary absence of integration set setup). I ran all the integration tests as well locally, which went flawlessly.