### PR TITLE
Sl astradb vectorstore indexing

### DIFF
--- a/libs/astradb/langchain_astradb/storage.py
+++ b/libs/astradb/langchain_astradb/storage.py
@@ -29,7 +29,20 @@ class AstraDBBaseStore(Generic[V], BaseStore[str, V], ABC):
     """Base class for the DataStax AstraDB data store."""
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
-        self.astra_env = _AstraDBCollectionEnvironment(*args, **kwargs)
+        if "requested_indexing_policy" in kwargs:
+            raise ValueError(
+                "Do not pass 'requested_indexing_policy' to AstraDBBaseStore init"
+            )
+        if "default_indexing_policy" in kwargs:
+            raise ValueError(
+                "Do not pass 'default_indexing_policy' to AstraDBBaseStore init"
+            )
+        kwargs["requested_indexing_policy"] = {"allow": ["_id"]}
+        kwargs["default_indexing_policy"] = {"allow": ["_id"]}
+        self.astra_env = _AstraDBCollectionEnvironment(
+            *args,
+            **kwargs,
+        )
         self.collection = self.astra_env.collection
         self.async_collection = self.astra_env.async_collection
 

--- a/libs/astradb/langchain_astradb/utils/astradb.py
+++ b/libs/astradb/langchain_astradb/utils/astradb.py
@@ -247,8 +247,9 @@ class _AstraDBCollectionEnvironment(_AstraDBEnvironment):
                     warnings.warn(
                         (
                             f"Astra DB collection '{collection_name}' is "
-                            "detected as legacy and has indexing turned "
-                            "on for all fields. This implies stricter "
+                            "detected as having indexing turned on for all "
+                            "fields (either created manually or by older "
+                            "versions of this plugin). This implies stricter "
                             "limitations on the amount of text each string in a "
                             "document can store. Consider reindexing anew on a "
                             "fresh collection to be able to store longer texts."
@@ -259,8 +260,9 @@ class _AstraDBCollectionEnvironment(_AstraDBEnvironment):
                 else:
                     raise ValueError(
                         f"Astra DB collection '{collection_name}' is "
-                        "detected as legacy and has indexing turned "
-                        "on for all fields. This is incompatible with "
+                        "detected as having indexing turned on for all "
+                        "fields (either created manually or by older "
+                        "versions of this plugin). This is incompatible with "
                         "the requested indexing policy for this object. "
                         "Consider reindexing anew on a fresh "
                         "collection with the requested indexing "

--- a/libs/astradb/langchain_astradb/utils/astradb.py
+++ b/libs/astradb/langchain_astradb/utils/astradb.py
@@ -2,11 +2,14 @@ from __future__ import annotations
 
 import asyncio
 import inspect
+import json
+import warnings
 from asyncio import InvalidStateError, Task
 from enum import Enum
-from typing import Awaitable, Optional, Union
+from typing import Any, Awaitable, Dict, List, Optional, Union
 
 import langchain_core
+from astrapy.api import APIRequestError
 from astrapy.db import AstraDB, AsyncAstraDB
 
 
@@ -89,6 +92,8 @@ class _AstraDBCollectionEnvironment(_AstraDBEnvironment):
         pre_delete_collection: bool = False,
         embedding_dimension: Union[int, Awaitable[int], None] = None,
         metric: Optional[str] = None,
+        requested_indexing_policy: Optional[Dict[str, Any]] = None,
+        default_indexing_policy: Optional[Dict[str, Any]] = None,
     ) -> None:
         from astrapy.db import AstraDBCollection, AsyncAstraDBCollection
 
@@ -106,6 +111,11 @@ class _AstraDBCollectionEnvironment(_AstraDBEnvironment):
             astra_db=self.async_astra_db,
         )
 
+        if requested_indexing_policy is not None:
+            _options = {"indexing": requested_indexing_policy}
+        else:
+            _options = None
+
         self.async_setup_db_task: Optional[Task] = None
         if setup_mode == SetupMode.ASYNC:
             async_astra_db = self.async_astra_db
@@ -117,9 +127,31 @@ class _AstraDBCollectionEnvironment(_AstraDBEnvironment):
                     dimension = await embedding_dimension
                 else:
                     dimension = embedding_dimension
-                await async_astra_db.create_collection(
-                    collection_name, dimension=dimension, metric=metric
-                )
+
+                try:
+                    await async_astra_db.create_collection(
+                        collection_name,
+                        dimension=dimension,
+                        metric=metric,
+                        options=_options,
+                    )
+                except (APIRequestError, ValueError):
+                    # possibly the collection is preexisting and may have legacy,
+                    # or custom, indexing settings: verify
+                    get_coll_response = await async_astra_db.get_collections(
+                        options={"explain": True}
+                    )
+                    collections = (get_coll_response["status"] or {}).get(
+                        "collections"
+                    ) or []
+                    if not self._validate_indexing_policy(
+                        detected_collections=collections,
+                        collection_name=self.collection_name,
+                        requested_indexing_policy=requested_indexing_policy,
+                        default_indexing_policy=default_indexing_policy,
+                    ):
+                        # other reasons for the exception
+                        raise
 
             self.async_setup_db_task = asyncio.create_task(_setup_db())
         elif setup_mode == SetupMode.SYNC:
@@ -130,11 +162,137 @@ class _AstraDBCollectionEnvironment(_AstraDBEnvironment):
                     "Cannot use an awaitable embedding_dimension with async_setup "
                     "set to False"
                 )
-            self.astra_db.create_collection(
-                collection_name,
-                dimension=embedding_dimension,  # type: ignore[arg-type]
-                metric=metric,
+            else:
+                try:
+                    self.astra_db.create_collection(
+                        collection_name,
+                        dimension=embedding_dimension,  # type: ignore[arg-type]
+                        metric=metric,
+                        options=_options,
+                    )
+                except (APIRequestError, ValueError):
+                    # possibly the collection is preexisting and may have legacy,
+                    # or custom, indexing settings: verify
+                    get_coll_response = self.astra_db.get_collections(  # type: ignore[union-attr]
+                        options={"explain": True}
+                    )
+                    collections = (get_coll_response["status"] or {}).get(
+                        "collections"
+                    ) or []
+                    if not self._validate_indexing_policy(
+                        detected_collections=collections,
+                        collection_name=self.collection_name,
+                        requested_indexing_policy=requested_indexing_policy,
+                        default_indexing_policy=default_indexing_policy,
+                    ):
+                        # other reasons for the exception
+                        raise
+
+    @staticmethod
+    def _validate_indexing_policy(
+        detected_collections: List[Dict[str, Any]],
+        collection_name: str,
+        requested_indexing_policy: Optional[Dict[str, Any]],
+        default_indexing_policy: Optional[Dict[str, Any]],
+    ) -> bool:
+        """
+        This is a validation helper, to be called when the collection-creation
+        call has failed.
+
+        Args:
+            detected_collection (List[Dict[str, Any]]):
+                the list of collection items returned by astrapy
+            collection_name (str): the name of the collection whose attempted
+                creation failed
+            requested_indexing_policy: the 'indexing' part of the collection
+                options, e.g. `{"deny": ["field1", "field2"]}`.
+                Leave to its default of None if no options required.
+            default_indexing_policy: an optional 'default value' for the
+                above, used to issue just a gentle warning in the special
+                case that no policy is detected on a preexisting collection
+                on DB and the default is requested. This is to enable
+                a warning-only transition to new code using indexing without
+                disrupting usage of a legacy collection, i.e. one created
+                before adopting the usage of indexing policies altogether.
+                You cannot pass this one without requested_indexing_policy.
+
+        This function may raise an error (indexing mismatches), issue a warning
+        (about legacy collections), or do nothing.
+        In any case, when the function returns, it returns either
+            - True: the exception was handled here as part of the indexing
+              management
+            - False: the exception is unrelated to indexing and the caller
+              has to reraise it.
+        """
+        if requested_indexing_policy is None and default_indexing_policy is not None:
+            raise ValueError(
+                "Cannot specify a default indexing policy "
+                "when no indexing policy is requested for this collection "
+                "(requested_indexing_policy is None, "
+                "default_indexing_policy is not None)."
             )
+
+        preexisting = [
+            collection
+            for collection in detected_collections
+            if collection["name"] == collection_name
+        ]
+        if preexisting:
+            pre_collection = preexisting[0]
+            # if it has no "indexing", it is a legacy collection
+            pre_col_options = pre_collection.get("options") or {}
+            if "indexing" not in pre_col_options:
+                # legacy collection on DB
+                if requested_indexing_policy == default_indexing_policy:
+                    warnings.warn(
+                        (
+                            f"Astra DB collection '{collection_name}' is "
+                            "detected as legacy and has indexing turned "
+                            "on for all fields. This implies stricter "
+                            "limitations on the amount of text each string in a "
+                            "document can store. Consider reindexing anew on a "
+                            "fresh collection to be able to store longer texts."
+                        ),
+                        UserWarning,
+                        stacklevel=2,
+                    )
+                else:
+                    raise ValueError(
+                        f"Astra DB collection '{collection_name}' is "
+                        "detected as legacy and has indexing turned "
+                        "on for all fields. This is incompatible with "
+                        "the requested indexing policy for this object. "
+                        "Consider reindexing anew on a fresh "
+                        "collection with the requested indexing "
+                        "policy, or alternatively leave the indexing "
+                        "settings for this object to their defaults "
+                        "to keep using this collection."
+                    )
+            elif pre_col_options["indexing"] != requested_indexing_policy:
+                # collection on DB has indexing settings, but different
+                options_json = json.dumps(pre_col_options["indexing"])
+                if pre_col_options["indexing"] == default_indexing_policy:
+                    default_desc = " (default setting)"
+                else:
+                    default_desc = ""
+                raise ValueError(
+                    f"Astra DB collection '{collection_name}' is "
+                    "detected as having the following indexing policy: "
+                    f"{options_json}{default_desc}. This is incompatible "
+                    "with the requested indexing policy for this object. "
+                    "Consider reindexing anew on a fresh "
+                    "collection with the requested indexing "
+                    "policy, or alternatively align the requested "
+                    "indexing settings to the collection to keep using it."
+                )
+            else:
+                # the discrepancies have to do with options other than indexing
+                return False
+            # the original exception, related to indexing, was handled here
+            return True
+        else:
+            # foreign-origin for the original exception
+            return False
 
     def ensure_db_setup(self) -> None:
         if self.async_setup_db_task:

--- a/libs/astradb/tests/integration_tests/test_vectorstores.py
+++ b/libs/astradb/tests/integration_tests/test_vectorstores.py
@@ -16,9 +16,11 @@ Required to run this test:
 import json
 import math
 import os
+import warnings
 from typing import Iterable, List, Optional, TypedDict
 
 import pytest
+from astrapy.db import AstraDB, AsyncAstraDB
 from langchain_core.documents import Document
 from langchain_core.embeddings import Embeddings
 
@@ -163,7 +165,6 @@ class TestAstraDBVectorStore:
         self, astradb_credentials: AstraDBCredentials
     ) -> None:
         """Create and delete."""
-        from astrapy.db import AstraDB as LibAstraDB
 
         emb = SomeEmbeddings(dimension=2)
         # creation by passing the connection secrets
@@ -179,7 +180,7 @@ class TestAstraDBVectorStore:
             v_store.clear()
 
         # Creation by passing a ready-made astrapy client:
-        astra_db_client = LibAstraDB(
+        astra_db_client = AstraDB(
             **astradb_credentials,
         )
         v_store_2 = AstraDBVectorStore(
@@ -206,8 +207,6 @@ class TestAstraDBVectorStore:
         )
         await v_store.adelete_collection()
         # Creation by passing a ready-made astrapy client:
-        from astrapy.db import AsyncAstraDB
-
         astra_db_client = AsyncAstraDB(
             **astradb_credentials,
         )
@@ -866,3 +865,188 @@ class TestAstraDBVectorStore:
                 vstore_euc.delete_collection()
             else:
                 vstore_euc.clear()
+
+    def test_astradb_vectorstore_indexing(self) -> None:
+        """
+        Test that the right errors/warnings are issued depending
+        on the compatibility of on-DB indexing settings and the requested ones.
+
+        We do NOT check for substrings in the warning messages: that would
+        be too brittle a test.
+        """
+        astra_db = AstraDB(
+            token=os.environ["ASTRA_DB_APPLICATION_TOKEN"],
+            api_endpoint=os.environ["ASTRA_DB_API_ENDPOINT"],
+            namespace=os.environ.get("ASTRA_DB_KEYSPACE"),
+        )
+
+        embe = SomeEmbeddings(dimension=2)
+
+        # creation of three collections to test warnings against
+        astra_db.create_collection("lc_legacy_coll", dimension=2, metric=None)
+        AstraDBVectorStore(
+            astra_db_client=astra_db,
+            collection_name="lc_default_idx",
+            embedding=embe,
+        )
+        AstraDBVectorStore(
+            astra_db_client=astra_db,
+            collection_name="lc_custom_idx",
+            embedding=embe,
+            metadata_indexing_exclude={"long_summary", "the_divine_comedy"},
+        )
+
+        # these invocations should just work without warnings
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            AstraDBVectorStore(
+                astra_db_client=astra_db,
+                collection_name="lc_default_idx",
+                embedding=embe,
+            )
+            AstraDBVectorStore(
+                astra_db_client=astra_db,
+                collection_name="lc_custom_idx",
+                embedding=embe,
+                metadata_indexing_exclude={"long_summary", "the_divine_comedy"},
+            )
+
+        # some are to throw an error:
+        with pytest.raises(ValueError):
+            AstraDBVectorStore(
+                astra_db_client=astra_db,
+                collection_name="lc_default_idx",
+                embedding=embe,
+                metadata_indexing_exclude={"long_summary", "the_divine_comedy"},
+            )
+
+        with pytest.raises(ValueError):
+            AstraDBVectorStore(
+                astra_db_client=astra_db,
+                collection_name="lc_custom_idx",
+                embedding=embe,
+                metadata_indexing_exclude={"changed_fields"},
+            )
+
+        with pytest.raises(ValueError):
+            AstraDBVectorStore(
+                astra_db_client=astra_db,
+                collection_name="lc_custom_idx",
+                embedding=embe,
+            )
+
+        with pytest.raises(ValueError):
+            AstraDBVectorStore(
+                astra_db_client=astra_db,
+                collection_name="lc_legacy_coll",
+                embedding=embe,
+                metadata_indexing_exclude={"long_summary", "the_divine_comedy"},
+            )
+
+        # one case should result in just a warning:
+        with pytest.warns(UserWarning) as rec_warnings:
+            AstraDBVectorStore(
+                astra_db_client=astra_db,
+                collection_name="lc_legacy_coll",
+                embedding=embe,
+            )
+            assert len(rec_warnings) == 1
+
+        # cleanup
+        astra_db.delete_collection("lc_legacy_coll")
+        astra_db.delete_collection("lc_default_idx")
+        astra_db.delete_collection("lc_custom_idx")
+
+    async def test_astradb_vectorstore_indexing_async(self) -> None:
+        """
+        Async version of the same test on warnings/errors related
+        to incompatible indexing choices.
+        """
+        astra_db = AsyncAstraDB(
+            token=os.environ["ASTRA_DB_APPLICATION_TOKEN"],
+            api_endpoint=os.environ["ASTRA_DB_API_ENDPOINT"],
+            namespace=os.environ.get("ASTRA_DB_KEYSPACE"),
+        )
+
+        embe = SomeEmbeddings(dimension=2)
+
+        # creation of three collections to test warnings against
+        await astra_db.create_collection("lc_legacy_coll", dimension=2, metric=None)
+        AstraDBVectorStore(
+            async_astra_db_client=astra_db,
+            collection_name="lc_default_idx",
+            embedding=embe,
+        )
+        AstraDBVectorStore(
+            async_astra_db_client=astra_db,
+            collection_name="lc_custom_idx",
+            embedding=embe,
+            metadata_indexing_exclude={"long_summary", "the_divine_comedy"},
+        )
+
+        # these invocations should just work without warnings
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            def_store = AstraDBVectorStore(
+                async_astra_db_client=astra_db,
+                collection_name="lc_default_idx",
+                embedding=embe,
+            )
+            await def_store.aadd_texts(["All good."])
+            cus_store = AstraDBVectorStore(
+                async_astra_db_client=astra_db,
+                collection_name="lc_custom_idx",
+                embedding=embe,
+                metadata_indexing_exclude={"long_summary", "the_divine_comedy"},
+            )
+            await cus_store.aadd_texts(["All good."])
+
+        # some are to throw an error:
+        with pytest.raises(ValueError):
+            def_store = AstraDBVectorStore(
+                async_astra_db_client=astra_db,
+                collection_name="lc_default_idx",
+                embedding=embe,
+                metadata_indexing_exclude={"long_summary", "the_divine_comedy"},
+            )
+            await def_store.aadd_texts(["Not working."])
+
+        with pytest.raises(ValueError):
+            cus_store = AstraDBVectorStore(
+                async_astra_db_client=astra_db,
+                collection_name="lc_custom_idx",
+                embedding=embe,
+                metadata_indexing_exclude={"changed_fields"},
+            )
+            await cus_store.aadd_texts(["Not working."])
+
+        with pytest.raises(ValueError):
+            cus_store = AstraDBVectorStore(
+                async_astra_db_client=astra_db,
+                collection_name="lc_custom_idx",
+                embedding=embe,
+            )
+            await cus_store.aadd_texts(["Not working."])
+
+        with pytest.raises(ValueError):
+            leg_store = AstraDBVectorStore(
+                async_astra_db_client=astra_db,
+                collection_name="lc_legacy_coll",
+                embedding=embe,
+                metadata_indexing_exclude={"long_summary", "the_divine_comedy"},
+            )
+            await leg_store.aadd_texts(["Not working."])
+
+        # one case should result in just a warning:
+        with pytest.warns(UserWarning) as rec_warnings:
+            leg_store = AstraDBVectorStore(
+                async_astra_db_client=astra_db,
+                collection_name="lc_legacy_coll",
+                embedding=embe,
+            )
+            await leg_store.aadd_texts(["Triggering warning."])
+            assert len(rec_warnings) == 1
+
+        await astra_db.delete_collection("lc_legacy_coll")
+        await astra_db.delete_collection("lc_default_idx")
+        await astra_db.delete_collection("lc_custom_idx")

--- a/libs/astradb/tests/unit_tests/test_vectorstores.py
+++ b/libs/astradb/tests/unit_tests/test_vectorstores.py
@@ -1,9 +1,13 @@
 from typing import List
 from unittest.mock import Mock
 
+import pytest
 from langchain_core.embeddings import Embeddings
 
-from langchain_astradb.vectorstores import AstraDBVectorStore
+from langchain_astradb.vectorstores import (
+    DEFAULT_INDEXING_OPTIONS,
+    AstraDBVectorStore,
+)
 
 
 class SomeEmbeddings(Embeddings):
@@ -34,12 +38,74 @@ class SomeEmbeddings(Embeddings):
         return self.embed_query(text)
 
 
-def test_initialization() -> None:
-    """Test integration vectorstore initialization."""
-    mock_astra_db = Mock()
-    embedding = SomeEmbeddings(dimension=2)
-    AstraDBVectorStore(
-        embedding=embedding,
-        collection_name="mock_coll_name",
-        astra_db_client=mock_astra_db,
-    )
+class TestAstraDB:
+    def test_initialization(self) -> None:
+        """Test integration vectorstore initialization."""
+        mock_astra_db = Mock()
+        embedding = SomeEmbeddings(dimension=2)
+        AstraDBVectorStore(
+            embedding=embedding,
+            collection_name="mock_coll_name",
+            astra_db_client=mock_astra_db,
+        )
+
+    def test_astradb_vectorstore_unit_indexing_normalization(self) -> None:
+        """Unit test of the indexing policy normalization"""
+        n3_idx = AstraDBVectorStore._normalize_metadata_indexing_policy(
+            metadata_indexing_include=None,
+            metadata_indexing_exclude=None,
+            collection_indexing_policy=None,
+        )
+        assert n3_idx == DEFAULT_INDEXING_OPTIONS
+
+        al_idx = AstraDBVectorStore._normalize_metadata_indexing_policy(
+            metadata_indexing_include=["a1", "a2"],
+            metadata_indexing_exclude=None,
+            collection_indexing_policy=None,
+        )
+        assert al_idx == {"allow": ["metadata.a1", "metadata.a2"]}
+
+        dl_idx = AstraDBVectorStore._normalize_metadata_indexing_policy(
+            metadata_indexing_include=None,
+            metadata_indexing_exclude=["d1", "d2"],
+            collection_indexing_policy=None,
+        )
+        assert dl_idx == {"deny": ["metadata.d1", "metadata.d2"]}
+
+        custom_policy = {
+            "deny": ["myfield", "other_field.subfield", "metadata.long_text"]
+        }
+        cip_idx = AstraDBVectorStore._normalize_metadata_indexing_policy(
+            metadata_indexing_include=None,
+            metadata_indexing_exclude=None,
+            collection_indexing_policy=custom_policy,
+        )
+        assert cip_idx == custom_policy
+
+        with pytest.raises(ValueError):
+            AstraDBVectorStore._normalize_metadata_indexing_policy(
+                metadata_indexing_include=["a"],
+                metadata_indexing_exclude=["b"],
+                collection_indexing_policy=None,
+            )
+
+        with pytest.raises(ValueError):
+            AstraDBVectorStore._normalize_metadata_indexing_policy(
+                metadata_indexing_include=["a"],
+                metadata_indexing_exclude=None,
+                collection_indexing_policy={"a": "z"},
+            )
+
+        with pytest.raises(ValueError):
+            AstraDBVectorStore._normalize_metadata_indexing_policy(
+                metadata_indexing_include=None,
+                metadata_indexing_exclude=["b"],
+                collection_indexing_policy={"a": "z"},
+            )
+
+        with pytest.raises(ValueError):
+            AstraDBVectorStore._normalize_metadata_indexing_policy(
+                metadata_indexing_include=["a"],
+                metadata_indexing_exclude=["b"],
+                collection_indexing_policy={"a": "z"},
+            )


### PR DESCRIPTION
Indexing options exposed in astradb.py (including the logic to warn/error if mismatches) and its usage in the VectorStore and Storage classes.

**Note** (for the temporary absence of integration set setup). I ran all the integration tests as well locally, which went flawlessly.