### PR TITLE
add filter to document_loaders test to avoid randomness flakiness

### DIFF
--- a/libs/astradb/tests/integration_tests/test_document_loaders.py
+++ b/libs/astradb/tests/integration_tests/test_document_loaders.py
@@ -111,6 +111,7 @@ class TestAstraDB:
             namespace=ASTRA_DB_KEYSPACE,
             find_options={"limit": 30},
             page_content_mapper=lambda x: x["foo"],
+            filter_criteria={"foo": "bar"},
         )
         docs = loader.lazy_load()
         doc = next(docs)
@@ -125,6 +126,7 @@ class TestAstraDB:
             namespace=ASTRA_DB_KEYSPACE,
             find_options={"limit": 30},
             metadata_mapper=lambda x: {"a": x["foo"]},
+            filter_criteria={"foo": "bar"},
         )
         docs = loader.lazy_load()
         doc = next(docs)
@@ -175,6 +177,7 @@ class TestAstraDB:
             namespace=ASTRA_DB_KEYSPACE,
             find_options={"limit": 30},
             page_content_mapper=lambda x: x["foo"],
+            filter_criteria={"foo": "bar"},
         )
         doc = await loader.alazy_load().__anext__()
         assert doc.page_content == "bar"
@@ -189,6 +192,7 @@ class TestAstraDB:
             namespace=ASTRA_DB_KEYSPACE,
             find_options={"limit": 30},
             metadata_mapper=lambda x: {"a": x["foo"]},
+            filter_criteria={"foo": "bar"},
         )
         doc = await loader.alazy_load().__anext__()
         assert doc.metadata == {"a": "bar"}


### PR DESCRIPTION
With 28 documents being inserted in the collection and 4 of them "bar2" (randomly positioned in UUID ordering), there was a ~14% chance that the first one being read in the test was "bar2", which failed the test. I added `filter_criteria` where needed and now there should be no risk anymore.