### PR TITLE
DB reads make their projection(+similarity) explicit where needed

### DIFF
--- a/libs/astradb/langchain_astradb/document_loaders.py
+++ b/libs/astradb/langchain_astradb/document_loaders.py
@@ -10,7 +10,6 @@ from typing import (
     Iterator,
     List,
     Optional,
-    Union,
 )
 
 from astrapy.db import AstraDB, AsyncAstraDB
@@ -38,7 +37,7 @@ class AstraDBLoader(BaseLoader):
         async_astra_db_client: Optional[AsyncAstraDB] = None,
         namespace: Optional[str] = None,
         filter_criteria: Optional[Dict[str, Any]] = None,
-        projection: Union[object, Optional[Dict[str, Any]]] = _NOT_SET,
+        projection: Optional[Dict[str, Any]] = _NOT_SET,  # type: ignore[assignment]
         find_options: Optional[Dict[str, Any]] = None,
         nb_prefetched: int = 1000,
         page_content_mapper: Callable[[Dict], str] = json.dumps,
@@ -58,7 +57,8 @@ class AstraDBLoader(BaseLoader):
             namespace: namespace (aka keyspace) where the
                 collection is. Defaults to the database's "default namespace".
             filter_criteria: Criteria to filter documents.
-            projection: Specifies the fields to return.
+            projection: Specifies the fields to return. If not provided, reads
+                fall back to the Data API default projection.
             find_options: Additional options for the query.
             nb_prefetched: Max number of documents to pre-fetch. Defaults to 1000.
             page_content_mapper: Function applied to collection documents to create
@@ -76,7 +76,7 @@ class AstraDBLoader(BaseLoader):
         self.astra_db_env = astra_db_env
         self.filter = filter_criteria
         self._projection: Optional[Dict[str, Any]] = (
-            projection if projection is not _NOT_SET else {"*": True}  # type: ignore[assignment]
+            projection if projection is not _NOT_SET else {"*": True}
         )
         self.find_options = find_options or {}
         self.nb_prefetched = nb_prefetched

--- a/libs/astradb/langchain_astradb/storage.py
+++ b/libs/astradb/langchain_astradb/storage.py
@@ -57,7 +57,10 @@ class AstraDBBaseStore(Generic[V], BaseStore[str, V], ABC):
     def mget(self, keys: Sequence[str]) -> List[Optional[V]]:
         self.astra_env.ensure_db_setup()
         docs_dict = {}
-        for doc in self.collection.paginated_find(filter={"_id": {"$in": list(keys)}}):
+        for doc in self.collection.paginated_find(
+            filter={"_id": {"$in": list(keys)}},
+            projection={"*": True},
+        ):
             docs_dict[doc["_id"]] = doc.get("value")
         return [self.decode_value(docs_dict.get(key)) for key in keys]
 
@@ -65,7 +68,8 @@ class AstraDBBaseStore(Generic[V], BaseStore[str, V], ABC):
         await self.astra_env.aensure_db_setup()
         docs_dict = {}
         async for doc in self.async_collection.paginated_find(
-            filter={"_id": {"$in": list(keys)}}
+            filter={"_id": {"$in": list(keys)}},
+            projection={"*": True},
         ):
             docs_dict[doc["_id"]] = doc.get("value")
         return [self.decode_value(docs_dict.get(key)) for key in keys]


### PR DESCRIPTION
In view of future changes in the API re: default projection and `$vector`, all classes that read from DB now specify their projection explicitly where needed.

This is done in a way that preserves unchanged behaviour as seen from the user's PoV.

An unfortunate byproduct is the typing of the `projection` argument to the `AstraDBLoader`, which was broadened to accommodate the special `_NOT_SET` object (for the sake of maintaining the same all-in-by-default behaviour as before the explicit projection). This might mistakenly suggest IDEs and such that objects are fine there.
I wonder if there's a way to constrain this hint better, perhaps with a TypeVar (?)