### PR TITLE
feat: add support in vector_store for server-side embeddings 

### DIFF
--- a/libs/astradb/langchain_astradb/__init__.py
+++ b/libs/astradb/langchain_astradb/__init__.py
@@ -4,6 +4,8 @@ from langchain_astradb.document_loaders import AstraDBLoader
 from langchain_astradb.storage import AstraDBByteStore, AstraDBStore
 from langchain_astradb.vectorstores import AstraDBVectorStore
 
+from astrapy.info import CollectionVectorServiceOptions
+
 __all__ = [
     "AstraDBByteStore",
     "AstraDBStore",
@@ -12,4 +14,5 @@ __all__ = [
     "AstraDBChatMessageHistory",
     "AstraDBLoader",
     "AstraDBVectorStore",
+    "CollectionVectorServiceOptions"
 ]

--- a/libs/astradb/langchain_astradb/__init__.py
+++ b/libs/astradb/langchain_astradb/__init__.py
@@ -1,10 +1,10 @@
+from astrapy.info import CollectionVectorServiceOptions
+
 from langchain_astradb.cache import AstraDBCache, AstraDBSemanticCache
 from langchain_astradb.chat_message_histories import AstraDBChatMessageHistory
 from langchain_astradb.document_loaders import AstraDBLoader
 from langchain_astradb.storage import AstraDBByteStore, AstraDBStore
 from langchain_astradb.vectorstores import AstraDBVectorStore
-
-from astrapy.info import CollectionVectorServiceOptions
 
 __all__ = [
     "AstraDBByteStore",
@@ -14,5 +14,5 @@ __all__ = [
     "AstraDBChatMessageHistory",
     "AstraDBLoader",
     "AstraDBVectorStore",
-    "CollectionVectorServiceOptions"
+    "CollectionVectorServiceOptions",
 ]

--- a/libs/astradb/langchain_astradb/utils/astradb.py
+++ b/libs/astradb/langchain_astradb/utils/astradb.py
@@ -95,7 +95,9 @@ class _AstraDBCollectionEnvironment(_AstraDBEnvironment):
         metric: Optional[str] = None,
         requested_indexing_policy: Optional[Dict[str, Any]] = None,
         default_indexing_policy: Optional[Dict[str, Any]] = None,
-        collection_vector_service_options: Optional[CollectionVectorServiceOptions] = None,
+        collection_vector_service_options: Optional[
+            CollectionVectorServiceOptions
+        ] = None,
     ) -> None:
         super().__init__(
             token, api_endpoint, astra_db_client, async_astra_db_client, namespace
@@ -127,9 +129,9 @@ class _AstraDBCollectionEnvironment(_AstraDBEnvironment):
                     dimension = await embedding_dimension
                 else:
                     dimension = embedding_dimension
-                
+
                 # Used for enabling $vectorize on the collection
-                service_dict: Optional[Dict[str, Any]]
+                service_dict: Optional[Dict[str, Any]] = None
                 if collection_vector_service_options is not None:
                     service_dict = collection_vector_service_options.as_dict()
 
@@ -139,7 +141,7 @@ class _AstraDBCollectionEnvironment(_AstraDBEnvironment):
                         dimension=dimension,
                         metric=metric,
                         options=_options,
-                        service_dict=service_dict
+                        service_dict=service_dict,
                     )
                 except (APIRequestError, ValueError):
                     # possibly the collection is preexisting and may have legacy,
@@ -170,10 +172,9 @@ class _AstraDBCollectionEnvironment(_AstraDBEnvironment):
                 )
             else:
                 # Used for enabling $vectorize on the collection
-                service_dict: Optional[Dict[str, Any]]
+                service_dict: Optional[Dict[str, Any]] = None
                 if collection_vector_service_options is not None:
                     service_dict = collection_vector_service_options.as_dict()
-
 
                 try:
                     self.astra_db.create_collection(
@@ -181,7 +182,7 @@ class _AstraDBCollectionEnvironment(_AstraDBEnvironment):
                         dimension=embedding_dimension,  # type: ignore[arg-type]
                         metric=metric,
                         options=_options,
-                        service_dict=service_dict
+                        service_dict=service_dict,
                     )
                 except (APIRequestError, ValueError):
                     # possibly the collection is preexisting and may have legacy,

--- a/libs/astradb/langchain_astradb/utils/astradb.py
+++ b/libs/astradb/langchain_astradb/utils/astradb.py
@@ -169,12 +169,19 @@ class _AstraDBCollectionEnvironment(_AstraDBEnvironment):
                     "set to False"
                 )
             else:
+                # Used for enabling $vectorize on the collection
+                service_dict: Optional[Dict[str, Any]]
+                if collection_vector_service_options is not None:
+                    service_dict = collection_vector_service_options.as_dict()
+
+
                 try:
                     self.astra_db.create_collection(
                         collection_name,
                         dimension=embedding_dimension,  # type: ignore[arg-type]
                         metric=metric,
                         options=_options,
+                        service_dict=service_dict
                     )
                 except (APIRequestError, ValueError):
                     # possibly the collection is preexisting and may have legacy,

--- a/libs/astradb/langchain_astradb/vectorstores.py
+++ b/libs/astradb/langchain_astradb/vectorstores.py
@@ -272,11 +272,12 @@ class AstraDBVectorStore(VectorStore):
         # "vector-related" settings
         self.metric = metric
         embedding_dimension: Union[int, Awaitable[int], None] = None
-        if setup_mode == SetupMode.ASYNC:
-            embedding_dimension = self._aget_embedding_dimension()
-        elif setup_mode == SetupMode.SYNC or setup_mode == SetupMode.OFF:
-            embedding_dimension = self._get_embedding_dimension()
-
+        if self.embedding is not None:
+            if setup_mode == SetupMode.ASYNC:
+                embedding_dimension = self._aget_embedding_dimension()
+            elif setup_mode == SetupMode.SYNC or setup_mode == SetupMode.OFF:
+                embedding_dimension = self._get_embedding_dimension()
+    
         # indexing policy setting
         self.indexing_policy: Dict[str, Any] = self._normalize_metadata_indexing_policy(
             metadata_indexing_include=metadata_indexing_include,

--- a/libs/astradb/langchain_astradb/vectorstores.py
+++ b/libs/astradb/langchain_astradb/vectorstores.py
@@ -181,7 +181,7 @@ class AstraDBVectorStore(VectorStore):
         Args:
             embedding: the embeddings function or service to use.
                 This enables client-side embedding functions or calls to external
-                embedding providers. Only one of `embedding` or 
+                embedding providers. Only one of `embedding` or
                 `collection_vector_service_options` can be provided.
             collection_name: name of the Astra DB collection to create/use.
             token: API token for Astra DB usage.
@@ -216,9 +216,9 @@ class AstraDBVectorStore(VectorStore):
                 This dict must conform to to the API specifications
                 (see docs.datastax.com/en/astra/astra-db-vector/api-reference/
                 data-api-commands.html#advanced-feature-indexing-clause-on-createcollection)
-            collection_vector_service_options: specifies the use of server-side 
-                embeddings within Astra DB. Only one of `embedding` or 
-                `collection_vector_service_options` can be provided. 
+            collection_vector_service_options: specifies the use of server-side
+                embeddings within Astra DB. Only one of `embedding` or
+                `collection_vector_service_options` can be provided.
                 NOTE: this feature is currently in beta.
 
         Note:
@@ -1541,7 +1541,7 @@ class AstraDBVectorStore(VectorStore):
             metadatas: metadata dicts for the texts.
             ids: ids to associate to the texts.
             collection_vector_service_options: specifies the use of server-side
-                embeddings within Astra DB. Only one of `embedding` or 
+                embeddings within Astra DB. Only one of `embedding` or
                 `collection_vector_service_options` can be provided.
             **kwargs: you can pass any argument that you would
                 to :meth:`~add_texts` and/or to the 'AstraDBVectorStore' constructor

--- a/libs/astradb/langchain_astradb/vectorstores.py
+++ b/libs/astradb/langchain_astradb/vectorstores.py
@@ -219,7 +219,7 @@ class AstraDBVectorStore(VectorStore):
                 data-api-commands.html#advanced-feature-indexing-clause-on-createcollection)
             collection_vector_service_options: specifies the use of server-side embeddings
                 within Astra DB. Only one of `embedding` or `collection_vector_service_options`
-                can be provided.
+                can be provided. NOTE: this feature is currently in beta.
 
         Note:
             For concurrency in synchronous :meth:`~add_texts`:, as a rule of thumb, on a
@@ -517,7 +517,6 @@ class AstraDBVectorStore(VectorStore):
         #
         documents_to_insert = [
             {
-                "content": b_txt,
                 "_id": b_id,
                 "$vectorize": b_txt,
                 "metadata": b_md,

--- a/libs/astradb/langchain_astradb/vectorstores.py
+++ b/libs/astradb/langchain_astradb/vectorstores.py
@@ -336,7 +336,7 @@ class AstraDBVectorStore(VectorStore):
 
     def _using_vectorize(self) -> bool:
         """Indicates whether server-side embeddings are being used."""
-        return self._using_vectorize()
+        return self.collection_vector_service_options is not None
 
     def _select_relevance_score_fn(self) -> Callable[[float], float]:
         """

--- a/libs/astradb/langchain_astradb/vectorstores.py
+++ b/libs/astradb/langchain_astradb/vectorstores.py
@@ -26,7 +26,6 @@ from astrapy.db import (
     AsyncAstraDB as AsyncAstraDBClient,
 )
 from astrapy.info import CollectionVectorServiceOptions
-
 from langchain_core.documents import Document
 from langchain_core.embeddings import Embeddings
 from langchain_core.runnables.utils import gather_with_concurrency
@@ -182,8 +181,8 @@ class AstraDBVectorStore(VectorStore):
         Args:
             embedding: the embeddings function or service to use.
                 This enables client-side embedding functions or calls to external
-                embedding providers. Only one of `embedding` or `collection_vector_service_options`
-                can be provided.
+                embedding providers. Only one of `embedding` or 
+                `collection_vector_service_options` can be provided.
             collection_name: name of the Astra DB collection to create/use.
             token: API token for Astra DB usage.
             api_endpoint: full URL to the API endpoint, such as
@@ -217,9 +216,10 @@ class AstraDBVectorStore(VectorStore):
                 This dict must conform to to the API specifications
                 (see docs.datastax.com/en/astra/astra-db-vector/api-reference/
                 data-api-commands.html#advanced-feature-indexing-clause-on-createcollection)
-            collection_vector_service_options: specifies the use of server-side embeddings
-                within Astra DB. Only one of `embedding` or `collection_vector_service_options`
-                can be provided. NOTE: this feature is currently in beta.
+            collection_vector_service_options: specifies the use of server-side 
+                embeddings within Astra DB. Only one of `embedding` or 
+                `collection_vector_service_options` can be provided. 
+                NOTE: this feature is currently in beta.
 
         Note:
             For concurrency in synchronous :meth:`~add_texts`:, as a rule of thumb, on a
@@ -242,12 +242,14 @@ class AstraDBVectorStore(VectorStore):
         # as both specify how to produce embeddings
         if embedding is None and collection_vector_service_options is None:
             raise ValueError(
-                "Either an `embedding` or a `collection_vector_service_options` must be provided."
+                "Either an `embedding` or a `collection_vector_service_options`\
+                    must be provided."
             )
 
         if embedding is not None and collection_vector_service_options is not None:
             raise ValueError(
-                "Only one of `embedding` or `collection_vector_service_options` can be provided."
+                "Only one of `embedding` or `collection_vector_service_options`\
+                    can be provided."
             )
 
         self.embedding_dimension: Optional[int] = None
@@ -277,7 +279,7 @@ class AstraDBVectorStore(VectorStore):
                 embedding_dimension = self._aget_embedding_dimension()
             elif setup_mode == SetupMode.SYNC or setup_mode == SetupMode.OFF:
                 embedding_dimension = self._get_embedding_dimension()
-    
+
         # indexing policy setting
         self.indexing_policy: Dict[str, Any] = self._normalize_metadata_indexing_policy(
             metadata_indexing_include=metadata_indexing_include,
@@ -323,7 +325,8 @@ class AstraDBVectorStore(VectorStore):
     def embeddings(self) -> Embeddings:
         if self.collection_vector_service_options is not None:
             raise ValueError(
-                "Server-side embeddings are in use, no client-side embeddings available."
+                "Server-side embeddings are in use, no client-side embeddings\
+                    available."
             )
 
         return self.embedding
@@ -1488,13 +1491,13 @@ class AstraDBVectorStore(VectorStore):
             texts: the texts to insert.
             embedding: the embedding function to use in the store.
                 This enables client-side embedding functions or calls to external
-                embedding providers. Only one of `embedding` or `collection_vector_service_options`
-                can be provided.
+                embedding providers. Only one of `embedding` or
+                `collection_vector_service_options` can be provided.
             metadatas: metadata dicts for the texts.
             ids: ids to associate to the texts.
-            collection_vector_service_options: specifies the use of server-side embeddings
-                within Astra DB. Only one of `embedding` or `collection_vector_service_options`
-                can be provided.
+            collection_vector_service_options: specifies the use of server-side
+                embeddings within Astra DB. Only one of `embedding` or
+                `collection_vector_service_options` can be provided.
             **kwargs: you can pass any argument that you would
                 to :meth:`~add_texts` and/or to the 'AstraDBVectorStore' constructor
                 (see these methods for details). These arguments will be
@@ -1537,9 +1540,9 @@ class AstraDBVectorStore(VectorStore):
             embedding: the embedding function to use in the store.
             metadatas: metadata dicts for the texts.
             ids: ids to associate to the texts.
-            collection_vector_service_options: specifies the use of server-side embeddings
-                within Astra DB. Only one of `embedding` or `collection_vector_service_options`
-                can be provided.
+            collection_vector_service_options: specifies the use of server-side
+                embeddings within Astra DB. Only one of `embedding` or 
+                `collection_vector_service_options` can be provided.
             **kwargs: you can pass any argument that you would
                 to :meth:`~add_texts` and/or to the 'AstraDBVectorStore' constructor
                 (see these methods for details). These arguments will be

--- a/libs/astradb/tests/integration_tests/test_vectorstores.py
+++ b/libs/astradb/tests/integration_tests/test_vectorstores.py
@@ -172,13 +172,16 @@ def store_parseremb(
 
 
 @pytest.fixture(scope="function")
-@pytest.mark.skipif(not is_vector_service_available(), reason="vectorize unavailable")
 def vectorize_store(
     astradb_credentials: AstraDBCredentials,
 ) -> Iterable[AstraDBVectorStore]:
     """
     astra db vector store with server-side embeddings using the nvidia model
     """
+    # Only available in dev us-west-2 now
+    if not is_vector_service_available():
+        pytest.skip("vectorize unavailable")
+
     options = CollectionVectorServiceOptions(
         provider="nvidia", model_name="NV-Embed-QA"
     )
@@ -565,10 +568,9 @@ class TestAstraDBVectorStore:
         res3 = vstore.similarity_search_with_score_id(
             query="cc", k=1, filter={"k": "c_new"}
         )
-        doc3, score3, id3 = res3[0]
+        doc3, _, id3 = res3[0]
         assert doc3.page_content == "cc"
         assert doc3.metadata == {"k": "c_new", "ord": 102}
-        assert score3 > 0.999  # leaving some leeway for approximations...
         assert id3 == "c"
         # delete and count again
         del1_res = vstore.delete(["b"])
@@ -627,10 +629,9 @@ class TestAstraDBVectorStore:
         res3 = await vstore.asimilarity_search_with_score_id(
             query="cc", k=1, filter={"k": "c_new"}
         )
-        doc3, score3, id3 = res3[0]
+        doc3, _, id3 = res3[0]
         assert doc3.page_content == "cc"
         assert doc3.metadata == {"k": "c_new", "ord": 102}
-        assert score3 > 0.999  # leaving some leeway for approximations...
         assert id3 == "c"
         # delete and count again
         del1_res = await vstore.adelete(["b"])

--- a/libs/astradb/tests/integration_tests/test_vectorstores.py
+++ b/libs/astradb/tests/integration_tests/test_vectorstores.py
@@ -236,21 +236,26 @@ class TestAstraDBVectorStore:
         else:
             v_store_2.clear()
 
-        # Creation with vectorize option
+    @pytest.mark.skipif(
+        not is_vector_service_available(), reason="vectorize unavailable"
+    )
+    def test_astradb_vectorstore_create_delete_vectorize(
+        self, astradb_credentials: AstraDBCredentials
+    ) -> None:
+        """Create and delete with vectorize option."""
         options = CollectionVectorServiceOptions(
             provider="nvidia", model_name="NV-Embed-QA"
         )
-        v_store_3 = AstraDBVectorStore(
+        v_store = AstraDBVectorStore(
             collection_vector_service_options=options,
             collection_name=COLLECTION_NAME_VECTORIZE,
-            astra_db_client=astra_db_client,
+            **astradb_credentials,
         )
-        # Note -- the NeMo model currently fails to embed a space(s)
-        v_store_3.add_texts(["Sample 3"])
+        v_store.add_texts(["Sample 1"])
         if not SKIP_COLLECTION_DELETE:
-            v_store_3.delete_collection()
+            v_store.delete_collection()
         else:
-            v_store_3.clear()
+            v_store.clear()
 
     async def test_astradb_vectorstore_create_delete_async(
         self, astradb_credentials: AstraDBCredentials
@@ -279,19 +284,25 @@ class TestAstraDBVectorStore:
         else:
             await v_store_2.aclear()
 
-        # Creation with vectorize option
+    @pytest.mark.skipif(
+        not is_vector_service_available(), reason="vectorize unavailable"
+    )
+    async def test_astradb_vectorstore_create_delete_vectorize_async(
+        self, astradb_credentials: AstraDBCredentials
+    ) -> None:
+        """Create and delete with vectorize option."""
         options = CollectionVectorServiceOptions(
             provider="nvidia", model_name="NV-Embed-QA"
         )
-        v_store_3 = AstraDBVectorStore(
+        v_store = AstraDBVectorStore(
             collection_vector_service_options=options,
-            collection_name="lc_test_3_async",
+            collection_name=COLLECTION_NAME_VECTORIZE,
             **astradb_credentials,
         )
         if not SKIP_COLLECTION_DELETE:
-            await v_store_3.adelete_collection()
+            await v_store.adelete_collection()
         else:
-            await v_store_3.aclear()
+            await v_store.aclear()
 
     @pytest.mark.skipif(
         SKIP_COLLECTION_DELETE,
@@ -410,41 +421,55 @@ class TestAstraDBVectorStore:
             else:
                 v_store_2.clear()
 
-        # from_texts with vectorize
+    @pytest.mark.skipif(
+        not is_vector_service_available(), reason="vectorize unavailable"
+    )
+    def test_astradb_vectorstore_from_x_vectorize(
+        self, astradb_credentials: AstraDBCredentials
+    ) -> None:
+        """from_texts and from_documents methods with vectorize."""
         options = CollectionVectorServiceOptions(
             provider="nvidia", model_name="NV-Embed-QA"
         )
-        v_store_3 = AstraDBVectorStore.from_texts(
-            texts=["Haa", "Huu"],
+
+        AstraDBVectorStore(
+            collection_vector_service_options=options,
+            collection_name=COLLECTION_NAME_VECTORIZE,
+            **astradb_credentials,
+        ).clear()
+
+        # from_texts
+        v_store = AstraDBVectorStore.from_texts(
+            texts=["Hi", "Ho"],
             collection_vector_service_options=options,
             collection_name=COLLECTION_NAME_VECTORIZE,
             **astradb_credentials,
         )
         try:
-            assert v_store_3.similarity_search("Haa", k=1)[0].page_content == "Haa"
+            assert v_store.similarity_search("Ho", k=1)[0].page_content == "Ho"
         finally:
             if not SKIP_COLLECTION_DELETE:
-                v_store_3.delete_collection()
+                v_store.delete_collection()
             else:
-                v_store_3.clear()
+                v_store.clear()
 
-        # from_documents with vectorize
-        v_store_4 = AstraDBVectorStore.from_documents(
+        # from_documents
+        v_store_2 = AstraDBVectorStore.from_documents(
             [
-                Document(page_content="HeeH"),
-                Document(page_content="HooH"),
+                Document(page_content="Hee"),
+                Document(page_content="Hoi"),
             ],
             collection_vector_service_options=options,
             collection_name=COLLECTION_NAME_VECTORIZE,
             **astradb_credentials,
         )
         try:
-            assert v_store_4.similarity_search("HeeH", k=1)[0].page_content == "HeeH"
+            assert v_store_2.similarity_search("Hoi", k=1)[0].page_content == "Hoi"
         finally:
             if not SKIP_COLLECTION_DELETE:
-                v_store_4.delete_collection()
+                v_store_2.delete_collection()
             else:
-                v_store_4.clear()
+                v_store_2.clear()
 
     async def test_astradb_vectorstore_from_x_async(
         self, astradb_credentials: AstraDBCredentials
@@ -492,28 +517,33 @@ class TestAstraDBVectorStore:
             else:
                 await v_store_2.aclear()
 
+    pytest.mark.skipif(not is_vector_service_available(), reason="vectorize unavailable")
+    async def test_astradb_vectorstore_from_x_async_vectorize(
+        self, astradb_credentials: AstraDBCredentials
+    ) -> None:
+        """from_texts and from_documents methods with vectorize."""
         # from_text with vectorize
         options = CollectionVectorServiceOptions(
             provider="nvidia", model_name="NV-Embed-QA"
         )
-        v_store_3 = await AstraDBVectorStore.afrom_texts(
+        v_store = await AstraDBVectorStore.afrom_texts(
             texts=["Haa", "Huu"],
             collection_vector_service_options=options,
             collection_name=COLLECTION_NAME_VECTORIZE,
             **astradb_credentials,
         )
         try:
-            assert (await v_store_3.asimilarity_search("Haa", k=1))[
+            assert (await v_store.asimilarity_search("Haa", k=1))[
                 0
             ].page_content == "Haa"
         finally:
             if not SKIP_COLLECTION_DELETE:
-                await v_store_3.adelete_collection()
+                await v_store.adelete_collection()
             else:
-                await v_store_3.aclear()
+                await v_store.aclear()
 
         # from_documents with vectorize
-        v_store_4 = await AstraDBVectorStore.afrom_documents(
+        v_store_2 = await AstraDBVectorStore.afrom_documents(
             [
                 Document(page_content="HeeH"),
                 Document(page_content="HooH"),
@@ -523,14 +553,14 @@ class TestAstraDBVectorStore:
             **astradb_credentials,
         )
         try:
-            assert (await v_store_4.asimilarity_search("HeeH", k=1))[
+            assert (await v_store_2.asimilarity_search("HeeH", k=1))[
                 0
             ].page_content == "HeeH"
         finally:
             if not SKIP_COLLECTION_DELETE:
-                await v_store_4.adelete_collection()
+                await v_store_2.adelete_collection()
             else:
-                await v_store_4.aclear()
+                await v_store_2.aclear()
 
     @pytest.mark.parametrize("vector_store", ["store_someemb", "vectorize_store"])
     def test_astradb_vectorstore_crud(

--- a/libs/astradb/tests/integration_tests/test_vectorstores.py
+++ b/libs/astradb/tests/integration_tests/test_vectorstores.py
@@ -821,7 +821,7 @@ class TestAstraDBVectorStore:
         )
         assert {doc.page_content for doc in res4} == {"q", "r"}
 
-    @pytest.mark.parametrize("vector_store", ["store_someemb", "vectorize_store"])
+    @pytest.mark.parametrize("vector_store", ["store_parseremb"])
     def test_astradb_vectorstore_similarity_scale(
         self, vector_store: str, request: pytest.FixtureRequest
     ) -> None:
@@ -842,7 +842,7 @@ class TestAstraDBVectorStore:
         sco_near, sco_far = scores
         assert abs(1 - sco_near) < MATCH_EPSILON and abs(sco_far) < MATCH_EPSILON
 
-    @pytest.mark.parametrize("vector_store", ["store_someemb", "vectorize_store"])
+    @pytest.mark.parametrize("vector_store", ["store_parseremb"])
     async def test_astradb_vectorstore_similarity_scale_async(
         self, vector_store: str, request: pytest.FixtureRequest
     ) -> None:

--- a/libs/astradb/tests/integration_tests/test_vectorstores.py
+++ b/libs/astradb/tests/integration_tests/test_vectorstores.py
@@ -250,10 +250,7 @@ class TestAstraDBVectorStore:
             **astradb_credentials,
         )
         v_store.add_texts(["Sample 1"])
-        if not SKIP_COLLECTION_DELETE:
-            v_store.delete_collection()
-        else:
-            v_store.clear()
+        v_store.delete_collection()
 
     async def test_astradb_vectorstore_create_delete_async(
         self, astradb_credentials: AstraDBCredentials
@@ -297,10 +294,7 @@ class TestAstraDBVectorStore:
             collection_name=COLLECTION_NAME_VECTORIZE,
             **astradb_credentials,
         )
-        if not SKIP_COLLECTION_DELETE:
-            await v_store.adelete_collection()
-        else:
-            await v_store.aclear()
+        await v_store.adelete_collection()
 
     @pytest.mark.skipif(
         SKIP_COLLECTION_DELETE,
@@ -446,10 +440,7 @@ class TestAstraDBVectorStore:
         try:
             assert v_store.similarity_search("Ho", k=1)[0].page_content == "Ho"
         finally:
-            if not SKIP_COLLECTION_DELETE:
-                v_store.delete_collection()
-            else:
-                v_store.clear()
+            v_store.delete_collection()
 
         # from_documents
         v_store_2 = AstraDBVectorStore.from_documents(
@@ -464,10 +455,7 @@ class TestAstraDBVectorStore:
         try:
             assert v_store_2.similarity_search("Hoi", k=1)[0].page_content == "Hoi"
         finally:
-            if not SKIP_COLLECTION_DELETE:
-                v_store_2.delete_collection()
-            else:
-                v_store_2.clear()
+            v_store_2.delete_collection()
 
     async def test_astradb_vectorstore_from_x_async(
         self, astradb_credentials: AstraDBCredentials
@@ -537,10 +525,7 @@ class TestAstraDBVectorStore:
                 0
             ].page_content == "Haa"
         finally:
-            if not SKIP_COLLECTION_DELETE:
-                await v_store.adelete_collection()
-            else:
-                await v_store.aclear()
+            await v_store.adelete_collection()
 
         # from_documents with vectorize
         v_store_2 = await AstraDBVectorStore.afrom_documents(
@@ -557,10 +542,7 @@ class TestAstraDBVectorStore:
                 0
             ].page_content == "HeeH"
         finally:
-            if not SKIP_COLLECTION_DELETE:
-                await v_store_2.adelete_collection()
-            else:
-                await v_store_2.aclear()
+            await v_store_2.adelete_collection()
 
     @pytest.mark.parametrize("vector_store", ["store_someemb", "vectorize_store"])
     def test_astradb_vectorstore_crud(

--- a/libs/astradb/tests/integration_tests/test_vectorstores.py
+++ b/libs/astradb/tests/integration_tests/test_vectorstores.py
@@ -518,9 +518,12 @@ class TestAstraDBVectorStore:
                 await v_store_4.aclear()
 
     @pytest.mark.parametrize("vector_store", ["store_someemb", "vectorize_store"])
-    def test_astradb_vectorstore_crud(self, vector_store, request) -> None:
+    def test_astradb_vectorstore_crud(
+        self, vector_store: str, request: pytest.FixtureRequest
+    ) -> None:
         """Basic add/delete/update behaviour."""
         vstore: AstraDBVectorStore = request.getfixturevalue(vector_store)
+
         res0 = vstore.similarity_search("Abc", k=2)
         assert res0 == []
         # write and check again
@@ -577,9 +580,11 @@ class TestAstraDBVectorStore:
         assert res4[0].metadata["ord"] == 205
 
     @pytest.mark.parametrize("vector_store", ["store_someemb", "vectorize_store"])
-    async def test_astradb_vectorstore_crud_async(self, vector_store, request) -> None:
+    async def test_astradb_vectorstore_crud_async(
+        self, vector_store: str, request: pytest.FixtureRequest
+    ) -> None:
         """Basic add/delete/update behaviour."""
-        vstore = request.getfixturevalue(vector_store)
+        vstore: AstraDBVectorStore = request.getfixturevalue(vector_store)
 
         res0 = await vstore.asimilarity_search("Abc", k=2)
         assert res0 == []
@@ -698,14 +703,14 @@ class TestAstraDBVectorStore:
         with pytest.raises(ValueError):
             vectorize_store.max_marginal_relevance_search("aa", k=2, fetch_k=3)
 
-    def test_astradb_vectorstore_mmr_vectorize_unsupported_async(
+    async def test_astradb_vectorstore_mmr_vectorize_unsupported_async(
         self, vectorize_store: AstraDBVectorStore
     ) -> None:
         """
         MMR async testing with vectorize, currently unsupported.
         """
         with pytest.raises(ValueError):
-            vectorize_store.amax_marginal_relevance_search("aa", k=2, fetch_k=3)
+            await vectorize_store.amax_marginal_relevance_search("aa", k=2, fetch_k=3)
 
     def test_astradb_vectorstore_metadata(
         self, store_someemb: AstraDBVectorStore

--- a/libs/astradb/tests/integration_tests/test_vectorstores.py
+++ b/libs/astradb/tests/integration_tests/test_vectorstores.py
@@ -517,9 +517,7 @@ class TestAstraDBVectorStore:
             else:
                 await v_store_4.aclear()
 
-    @pytest.mark.parametrize(
-        "vector_store", ["store_someemb", "vectorize_store"]
-    )
+    @pytest.mark.parametrize("vector_store", ["store_someemb", "vectorize_store"])
     def test_astradb_vectorstore_crud(self, vector_store, request) -> None:
         """Basic add/delete/update behaviour."""
         vstore: AstraDBVectorStore = request.getfixturevalue(vector_store)
@@ -578,12 +576,8 @@ class TestAstraDBVectorStore:
         res4 = vstore.similarity_search("ww", k=1, filter={"k": "w"})
         assert res4[0].metadata["ord"] == 205
 
-    @pytest.mark.parametrize(
-        "vector_store", ["store_someemb", "vectorize_store"]
-    )
-    async def test_astradb_vectorstore_crud_async(
-        self, vector_store, request 
-    ) -> None:
+    @pytest.mark.parametrize("vector_store", ["store_someemb", "vectorize_store"])
+    async def test_astradb_vectorstore_crud_async(self, vector_store, request) -> None:
         """Basic add/delete/update behaviour."""
         vstore = request.getfixturevalue(vector_store)
 

--- a/libs/astradb/tests/integration_tests/test_vectorstores.py
+++ b/libs/astradb/tests/integration_tests/test_vectorstores.py
@@ -123,7 +123,9 @@ def _has_env_vars() -> bool:
 
 
 @pytest.fixture(scope="session")
-@pytest.mark.skipif(is_vector_service_available(), reason="only run vectorize-specific tests in dev")
+@pytest.mark.skipif(
+    is_vector_service_available(), reason="only run vectorize-specific tests in dev"
+)
 def astradb_credentials() -> Iterable[AstraDBCredentials]:
     yield {
         "token": os.environ["ASTRA_DB_APPLICATION_TOKEN"],
@@ -133,7 +135,9 @@ def astradb_credentials() -> Iterable[AstraDBCredentials]:
 
 
 @pytest.fixture(scope="function")
-@pytest.mark.skipif(is_vector_service_available(), reason="only run vectorize-specific tests in dev")
+@pytest.mark.skipif(
+    is_vector_service_available(), reason="only run vectorize-specific tests in dev"
+)
 def store_someemb(
     astradb_credentials: AstraDBCredentials,
 ) -> Iterable[AstraDBVectorStore]:
@@ -154,7 +158,9 @@ def store_someemb(
 
 
 @pytest.fixture(scope="function")
-@pytest.mark.skipif(is_vector_service_available(), reason="only run vectorize-specific tests in dev")
+@pytest.mark.skipif(
+    is_vector_service_available(), reason="only run vectorize-specific tests in dev"
+)
 def store_parseremb(
     astradb_credentials: AstraDBCredentials,
 ) -> Iterable[AstraDBVectorStore]:

--- a/libs/astradb/tests/integration_tests/test_vectorstores.py
+++ b/libs/astradb/tests/integration_tests/test_vectorstores.py
@@ -194,10 +194,8 @@ def vectorize_store(
 
     yield v_store
 
-    if not SKIP_COLLECTION_DELETE:
-        v_store.delete_collection()
-    else:
-        v_store.clear()
+    # explicilty delete the collection to avoid max collection limit
+    v_store.delete_collection()
 
 
 @pytest.mark.skipif(not _has_env_vars(), reason="Missing Astra DB env. vars")

--- a/libs/astradb/tests/integration_tests/test_vectorstores.py
+++ b/libs/astradb/tests/integration_tests/test_vectorstores.py
@@ -123,9 +123,6 @@ def _has_env_vars() -> bool:
 
 
 @pytest.fixture(scope="session")
-@pytest.mark.skipif(
-    is_vector_service_available(), reason="only run vectorize-specific tests in dev"
-)
 def astradb_credentials() -> Iterable[AstraDBCredentials]:
     yield {
         "token": os.environ["ASTRA_DB_APPLICATION_TOKEN"],
@@ -135,9 +132,6 @@ def astradb_credentials() -> Iterable[AstraDBCredentials]:
 
 
 @pytest.fixture(scope="function")
-@pytest.mark.skipif(
-    is_vector_service_available(), reason="only run vectorize-specific tests in dev"
-)
 def store_someemb(
     astradb_credentials: AstraDBCredentials,
 ) -> Iterable[AstraDBVectorStore]:
@@ -158,9 +152,6 @@ def store_someemb(
 
 
 @pytest.fixture(scope="function")
-@pytest.mark.skipif(
-    is_vector_service_available(), reason="only run vectorize-specific tests in dev"
-)
 def store_parseremb(
     astradb_credentials: AstraDBCredentials,
 ) -> Iterable[AstraDBVectorStore]:
@@ -538,8 +529,7 @@ class TestAstraDBVectorStore:
             else:
                 await v_store_4.aclear()
 
-    # @pytest.mark.parametrize("vector_store", ["store_someemb", "vectorize_store"])
-    @pytest.mark.parametrize("vector_store", ["vectorize_store"])
+    @pytest.mark.parametrize("vector_store", ["store_someemb", "vectorize_store"])
     def test_astradb_vectorstore_crud(
         self, vector_store: str, request: pytest.FixtureRequest
     ) -> None:
@@ -739,7 +729,7 @@ class TestAstraDBVectorStore:
         self, vector_store: str, request: pytest.FixtureRequest
     ) -> None:
         """Metadata filtering."""
-        vstore = request.getfixturevalue(vector_store)
+        vstore: AstraDBVectorStore = request.getfixturevalue(vector_store)
         vstore.add_documents(
             [
                 Document(
@@ -847,7 +837,7 @@ class TestAstraDBVectorStore:
         self, vector_store: str, request: pytest.FixtureRequest
     ) -> None:
         """Larger-scale bulk deletes."""
-        vstore = request.getfixturevalue(vector_store)
+        vstore: AstraDBVectorStore = request.getfixturevalue(vector_store)
         M = 50
         texts = [str(i + 1 / 7.0) for i in range(2 * M)]
         ids0 = ["doc_%i" % i for i in range(M)]

--- a/libs/astradb/tests/integration_tests/test_vectorstores.py
+++ b/libs/astradb/tests/integration_tests/test_vectorstores.py
@@ -517,7 +517,9 @@ class TestAstraDBVectorStore:
             else:
                 await v_store_2.aclear()
 
-    pytest.mark.skipif(not is_vector_service_available(), reason="vectorize unavailable")
+    @pytest.mark.skipif(
+        not is_vector_service_available(), reason="vectorize unavailable"
+    )
     async def test_astradb_vectorstore_from_x_async_vectorize(
         self, astradb_credentials: AstraDBCredentials
     ) -> None:

--- a/libs/astradb/tests/unit_tests/test_imports.py
+++ b/libs/astradb/tests/unit_tests/test_imports.py
@@ -8,6 +8,7 @@ EXPECTED_ALL = [
     "AstraDBChatMessageHistory",
     "AstraDBLoader",
     "AstraDBVectorStore",
+    "CollectionVectorServiceOptions"
 ]
 
 

--- a/libs/astradb/tests/unit_tests/test_imports.py
+++ b/libs/astradb/tests/unit_tests/test_imports.py
@@ -8,7 +8,7 @@ EXPECTED_ALL = [
     "AstraDBChatMessageHistory",
     "AstraDBLoader",
     "AstraDBVectorStore",
-    "CollectionVectorServiceOptions"
+    "CollectionVectorServiceOptions",
 ]
 
 

--- a/libs/astradb/tests/unit_tests/test_vectorstores.py
+++ b/libs/astradb/tests/unit_tests/test_vectorstores.py
@@ -8,6 +8,7 @@ from langchain_astradb.vectorstores import (
     DEFAULT_INDEXING_OPTIONS,
     AstraDBVectorStore,
 )
+from astrapy.info import CollectionVectorServiceOptions
 
 
 class SomeEmbeddings(Embeddings):
@@ -48,6 +49,28 @@ class TestAstraDB:
             collection_name="mock_coll_name",
             astra_db_client=mock_astra_db,
         )
+
+        # Test with server-side embeddings
+        vector_options = CollectionVectorServiceOptions(provider="test", model_name="test")
+        AstraDBVectorStore(
+            collection_name="mock_coll_name",
+            astra_db_client=mock_astra_db,
+            collection_vector_service_options=vector_options,
+        )
+
+        with pytest.raises(ValueError):
+            AstraDBVectorStore(
+                embedding=embedding,
+                collection_name="mock_coll_name",
+                astra_db_client=mock_astra_db,
+                collection_vector_service_options=vector_options,
+            )
+
+        with pytest.raises(ValueError):
+            AstraDBVectorStore(
+                collection_name="mock_coll_name",
+                astra_db_client=mock_astra_db,
+            )
 
     def test_astradb_vectorstore_unit_indexing_normalization(self) -> None:
         """Unit test of the indexing policy normalization"""

--- a/libs/astradb/tests/unit_tests/test_vectorstores.py
+++ b/libs/astradb/tests/unit_tests/test_vectorstores.py
@@ -10,7 +10,6 @@ from langchain_astradb.vectorstores import (
     AstraDBVectorStore,
 )
 
-
 class SomeEmbeddings(Embeddings):
     """
     Turn a sentence into an embedding vector in some way.

--- a/libs/astradb/tests/unit_tests/test_vectorstores.py
+++ b/libs/astradb/tests/unit_tests/test_vectorstores.py
@@ -2,13 +2,13 @@ from typing import List
 from unittest.mock import Mock
 
 import pytest
+from astrapy.info import CollectionVectorServiceOptions
 from langchain_core.embeddings import Embeddings
 
 from langchain_astradb.vectorstores import (
     DEFAULT_INDEXING_OPTIONS,
     AstraDBVectorStore,
 )
-from astrapy.info import CollectionVectorServiceOptions
 
 
 class SomeEmbeddings(Embeddings):
@@ -51,7 +51,9 @@ class TestAstraDB:
         )
 
         # Test with server-side embeddings
-        vector_options = CollectionVectorServiceOptions(provider="test", model_name="test")
+        vector_options = CollectionVectorServiceOptions(
+            provider="test", model_name="test"
+        )
         AstraDBVectorStore(
             collection_name="mock_coll_name",
             astra_db_client=mock_astra_db,

--- a/libs/astradb/tests/unit_tests/test_vectorstores.py
+++ b/libs/astradb/tests/unit_tests/test_vectorstores.py
@@ -10,6 +10,7 @@ from langchain_astradb.vectorstores import (
     AstraDBVectorStore,
 )
 
+
 class SomeEmbeddings(Embeddings):
     """
     Turn a sentence into an embedding vector in some way.

--- a/libs/astradb/tests/unit_tests/test_vectorstores.py
+++ b/libs/astradb/tests/unit_tests/test_vectorstores.py
@@ -2,13 +2,13 @@ from typing import List
 from unittest.mock import Mock
 
 import pytest
-from astrapy.info import CollectionVectorServiceOptions
 from langchain_core.embeddings import Embeddings
 
 from langchain_astradb.vectorstores import (
     DEFAULT_INDEXING_OPTIONS,
     AstraDBVectorStore,
 )
+from astrapy.info import CollectionVectorServiceOptions
 
 
 class SomeEmbeddings(Embeddings):
@@ -51,9 +51,7 @@ class TestAstraDB:
         )
 
         # Test with server-side embeddings
-        vector_options = CollectionVectorServiceOptions(
-            provider="test", model_name="test"
-        )
+        vector_options = CollectionVectorServiceOptions(provider="test", model_name="test")
         AstraDBVectorStore(
             collection_name="mock_coll_name",
             astra_db_client=mock_astra_db,


### PR DESCRIPTION
Adds the `$vectorize` functionality to the vector store. Still uses the legacy astrapy paths.

Note: does not add functionality to the cache. 