### PR TITLE
Environment variables for Astra DB init

### DIFF
--- a/libs/astradb/langchain_astradb/cache.py
+++ b/libs/astradb/langchain_astradb/cache.py
@@ -112,15 +112,18 @@ class AstraDBCache(BaseCache):
 
         Args:
             collection_name: name of the Astra DB collection to create/use.
-            token: API token for Astra DB usage.
-            api_endpoint: full URL to the API endpoint,
-                such as `https://<DB-ID>-us-east1.apps.astra.datastax.com`.
+            token: API token for Astra DB usage. If not provided, the environment
+                variable ASTRA_DB_APPLICATION_TOKEN is inspected.
+            api_endpoint: full URL to the API endpoint, such as
+                `https://<DB-ID>-us-east1.apps.astra.datastax.com`. If not provided,
+                the environment variable ASTRA_DB_API_ENDPOINT is inspected.
             astra_db_client: *alternative to token+api_endpoint*,
                 you can pass an already-created 'astrapy.db.AstraDB' instance.
             async_astra_db_client: *alternative to token+api_endpoint*,
                 you can pass an already-created 'astrapy.db.AsyncAstraDB' instance.
-            namespace: namespace (aka keyspace) where the
-                collection is created. Defaults to the database's "default namespace".
+            namespace: namespace (aka keyspace) where the collection is created.
+                If not provided, the environment variable ASTRA_DB_KEYSPACE is
+                inspected. Defaults to the database's "default namespace".
             setup_mode: mode used to create the Astra DB collection (SYNC, ASYNC or
                 OFF).
             pre_delete_collection: whether to delete the collection
@@ -307,15 +310,18 @@ class AstraDBSemanticCache(BaseCache):
 
         Args:
             collection_name: name of the Astra DB collection to create/use.
-            token: API token for Astra DB usage.
-            api_endpoint: full URL to the API endpoint,
-                such as `https://<DB-ID>-us-east1.apps.astra.datastax.com`.
+            token: API token for Astra DB usage. If not provided, the environment
+                variable ASTRA_DB_APPLICATION_TOKEN is inspected.
+            api_endpoint: full URL to the API endpoint, such as
+                `https://<DB-ID>-us-east1.apps.astra.datastax.com`. If not provided,
+                the environment variable ASTRA_DB_API_ENDPOINT is inspected.
             astra_db_client: *alternative to token+api_endpoint*,
                 you can pass an already-created 'astrapy.db.AstraDB' instance.
             async_astra_db_client: *alternative to token+api_endpoint*,
                 you can pass an already-created 'astrapy.db.AsyncAstraDB' instance.
-            namespace: namespace (aka keyspace) where the
-                collection is created. Defaults to the database's "default namespace".
+            namespace: namespace (aka keyspace) where the collection is created.
+                If not provided, the environment variable ASTRA_DB_KEYSPACE is
+                inspected. Defaults to the database's "default namespace".
             setup_mode: mode used to create the Astra DB collection (SYNC, ASYNC or
                 OFF).
             pre_delete_collection: whether to delete the collection

--- a/libs/astradb/langchain_astradb/chat_message_histories.py
+++ b/libs/astradb/langchain_astradb/chat_message_histories.py
@@ -41,15 +41,18 @@ class AstraDBChatMessageHistory(BaseChatMessageHistory):
             session_id: arbitrary key that is used to store the messages
                 of a single chat session.
             collection_name: name of the Astra DB collection to create/use.
-            token: API token for Astra DB usage.
-            api_endpoint: full URL to the API endpoint,
-                such as "https://<DB-ID>-us-east1.apps.astra.datastax.com".
+            token: API token for Astra DB usage. If not provided, the environment
+                variable ASTRA_DB_APPLICATION_TOKEN is inspected.
+            api_endpoint: full URL to the API endpoint, such as
+                `https://<DB-ID>-us-east1.apps.astra.datastax.com`. If not provided,
+                the environment variable ASTRA_DB_API_ENDPOINT is inspected.
             astra_db_client: *alternative to token+api_endpoint*,
                 you can pass an already-created 'astrapy.db.AstraDB' instance.
             async_astra_db_client: *alternative to token+api_endpoint*,
                 you can pass an already-created 'astrapy.db.AsyncAstraDB' instance.
-            namespace: namespace (aka keyspace) where the
-                collection is created. Defaults to the database's "default namespace".
+            namespace: namespace (aka keyspace) where the collection is created.
+                If not provided, the environment variable ASTRA_DB_KEYSPACE is
+                inspected. Defaults to the database's "default namespace".
         """
         self.astra_env = _AstraDBCollectionEnvironment(
             collection_name=collection_name,

--- a/libs/astradb/langchain_astradb/document_loaders.py
+++ b/libs/astradb/langchain_astradb/document_loaders.py
@@ -47,15 +47,18 @@ class AstraDBLoader(BaseLoader):
 
         Args:
             collection_name: name of the Astra DB collection to use.
-            token: API token for Astra DB usage.
-            api_endpoint: full URL to the API endpoint,
-                such as `https://<DB-ID>-us-east1.apps.astra.datastax.com`.
+            token: API token for Astra DB usage. If not provided, the environment
+                variable ASTRA_DB_APPLICATION_TOKEN is inspected.
+            api_endpoint: full URL to the API endpoint, such as
+                `https://<DB-ID>-us-east1.apps.astra.datastax.com`. If not provided,
+                the environment variable ASTRA_DB_API_ENDPOINT is inspected.
             astra_db_client: *alternative to token+api_endpoint*,
                 you can pass an already-created 'astrapy.db.AstraDB' instance.
             async_astra_db_client: *alternative to token+api_endpoint*,
                 you can pass an already-created 'astrapy.db.AsyncAstraDB' instance.
-            namespace: namespace (aka keyspace) where the
-                collection is. Defaults to the database's "default namespace".
+            namespace: namespace (aka keyspace) where the collection resides.
+                If not provided, the environment variable ASTRA_DB_KEYSPACE is
+                inspected. Defaults to the database's "default namespace".
             filter_criteria: Criteria to filter documents.
             projection: Specifies the fields to return. If not provided, reads
                 fall back to the Data API default projection.

--- a/libs/astradb/langchain_astradb/storage.py
+++ b/libs/astradb/langchain_astradb/storage.py
@@ -138,15 +138,18 @@ class AstraDBStore(AstraDBBaseStore[Any]):
 
         Args:
             collection_name: name of the Astra DB collection to create/use.
-            token: API token for Astra DB usage.
-            api_endpoint: full URL to the API endpoint,
-                such as `https://<DB-ID>-us-east1.apps.astra.datastax.com`.
+            token: API token for Astra DB usage. If not provided, the environment
+                variable ASTRA_DB_APPLICATION_TOKEN is inspected.
+            api_endpoint: full URL to the API endpoint, such as
+                `https://<DB-ID>-us-east1.apps.astra.datastax.com`. If not provided,
+                the environment variable ASTRA_DB_API_ENDPOINT is inspected.
             astra_db_client: *alternative to token+api_endpoint*,
                 you can pass an already-created 'astrapy.db.AstraDB' instance.
             async_astra_db_client: *alternative to token+api_endpoint*,
                 you can pass an already-created 'astrapy.db.AsyncAstraDB' instance.
-            namespace: namespace (aka keyspace) where the
-                collection is created. Defaults to the database's "default namespace".
+            namespace: namespace (aka keyspace) where the collection is created.
+                If not provided, the environment variable ASTRA_DB_KEYSPACE is
+                inspected. Defaults to the database's "default namespace".
             setup_mode: mode used to create the Astra DB collection (SYNC, ASYNC or
                 OFF).
             pre_delete_collection: whether to delete the collection
@@ -197,15 +200,18 @@ class AstraDBByteStore(AstraDBBaseStore[bytes], ByteStore):
 
         Args:
             collection_name: name of the Astra DB collection to create/use.
-            token: API token for Astra DB usage.
-            api_endpoint: full URL to the API endpoint,
-                such as `https://<DB-ID>-us-east1.apps.astra.datastax.com`.
+            token: API token for Astra DB usage. If not provided, the environment
+                variable ASTRA_DB_APPLICATION_TOKEN is inspected.
+            api_endpoint: full URL to the API endpoint, such as
+                `https://<DB-ID>-us-east1.apps.astra.datastax.com`. If not provided,
+                the environment variable ASTRA_DB_API_ENDPOINT is inspected.
             astra_db_client: *alternative to token+api_endpoint*,
                 you can pass an already-created 'astrapy.db.AstraDB' instance.
             async_astra_db_client: *alternative to token+api_endpoint*,
                 you can pass an already-created 'astrapy.db.AsyncAstraDB' instance.
-            namespace: namespace (aka keyspace) where the
-                collection is created. Defaults to the database's "default namespace".
+            namespace: namespace (aka keyspace) where the collection is created.
+                If not provided, the environment variable ASTRA_DB_KEYSPACE is
+                inspected. Defaults to the database's "default namespace".
             setup_mode: mode used to create the Astra DB collection (SYNC, ASYNC or
                 OFF).
             pre_delete_collection: whether to delete the collection

--- a/libs/astradb/langchain_astradb/vectorstores.py
+++ b/libs/astradb/langchain_astradb/vectorstores.py
@@ -184,15 +184,18 @@ class AstraDBVectorStore(VectorStore):
                 embedding providers. Only one of `embedding` or
                 `collection_vector_service_options` can be provided.
             collection_name: name of the Astra DB collection to create/use.
-            token: API token for Astra DB usage.
+            token: API token for Astra DB usage. If not provided, the environment
+                variable ASTRA_DB_APPLICATION_TOKEN is inspected.
             api_endpoint: full URL to the API endpoint, such as
-                `https://<DB-ID>-us-east1.apps.astra.datastax.com`.
+                `https://<DB-ID>-us-east1.apps.astra.datastax.com`. If not provided,
+                the environment variable ASTRA_DB_API_ENDPOINT is inspected.
             astra_db_client: *alternative to token+api_endpoint*,
                 you can pass an already-created 'astrapy.db.AstraDB' instance.
             async_astra_db_client: *alternative to token+api_endpoint*,
                 you can pass an already-created 'astrapy.db.AsyncAstraDB' instance.
             namespace: namespace (aka keyspace) where the collection is created.
-                Defaults to the database's "default namespace".
+                If not provided, the environment variable ASTRA_DB_KEYSPACE is
+                inspected. Defaults to the database's "default namespace".
             metric: similarity function to use out of those available in Astra DB.
                 If left out, it will use Astra DB API's defaults (i.e. "cosine" - but,
                 for performance reasons, "dot_product" is suggested if embeddings are

--- a/libs/astradb/tests/unit_tests/test_astra_db_environment.py
+++ b/libs/astradb/tests/unit_tests/test_astra_db_environment.py
@@ -1,0 +1,149 @@
+import os
+from unittest.mock import Mock
+
+import pytest
+
+from langchain_astradb.utils.astradb import (
+    API_ENDPOINT_ENV_VAR,
+    NAMESPACE_ENV_VAR,
+    TOKEN_ENV_VAR,
+    _AstraDBEnvironment,
+)
+
+
+class TestAstraDBEnvironment:
+    def test_initialization(self) -> None:
+        """Test the various ways to initialize the environment."""
+
+        # clean environment
+        if TOKEN_ENV_VAR in os.environ:
+            del os.environ["TOKEN_ENV_VAR"]
+        if API_ENDPOINT_ENV_VAR in os.environ:
+            del os.environ[API_ENDPOINT_ENV_VAR]
+        if NAMESPACE_ENV_VAR in os.environ:
+            del os.environ[NAMESPACE_ENV_VAR]
+
+        # token+endpoint
+        env1 = _AstraDBEnvironment(
+            token="t",
+            api_endpoint="ae",
+        )
+        assert env1.async_astra_db.token == "t"
+        assert env1.async_astra_db.api_endpoint == "ae"
+
+        # token+endpoint, but also a ready-made client
+        with pytest.raises(ValueError):
+            _AstraDBEnvironment(
+                token="t",
+                api_endpoint="ae",
+                astra_db_client=Mock(),
+            )
+        with pytest.raises(ValueError):
+            _AstraDBEnvironment(
+                token="t",
+                api_endpoint="ae",
+                async_astra_db_client=Mock(),
+            )
+
+        # just token or endpoint
+        with pytest.raises(ValueError):
+            _AstraDBEnvironment(
+                token="t",
+            )
+        with pytest.raises(ValueError):
+            _AstraDBEnvironment(
+                api_endpoint="ae",
+            )
+
+        # just client(s)
+        _AstraDBEnvironment(
+            async_astra_db_client=Mock(),
+        )
+        _AstraDBEnvironment(
+            astra_db_client=Mock(),
+        )
+        _AstraDBEnvironment(
+            astra_db_client=Mock(),
+            async_astra_db_client=Mock(),
+        )
+
+        # token+client
+        with pytest.raises(ValueError):
+            _AstraDBEnvironment(
+                token="t",
+                astra_db_client=Mock(),
+            )
+        # endpoint+client
+        with pytest.raises(ValueError):
+            _AstraDBEnvironment(
+                api_endpoint="ae",
+                async_astra_db_client=Mock(),
+            )
+
+        # token via environment variable:
+        os.environ[TOKEN_ENV_VAR] = "T"
+        env3 = _AstraDBEnvironment(
+            api_endpoint="ae",
+        )
+        assert env3.async_astra_db.token == "T"
+        assert env3.async_astra_db.api_endpoint == "ae"
+
+        # endpoint via environment variable:
+        del os.environ[TOKEN_ENV_VAR]
+        os.environ[API_ENDPOINT_ENV_VAR] = "AE"
+        env4 = _AstraDBEnvironment(
+            token="t",
+        )
+        assert env4.async_astra_db.token == "t"
+        assert env4.async_astra_db.api_endpoint == "AE"
+
+        # both via env vars
+        os.environ[TOKEN_ENV_VAR] = "T"
+        os.environ[API_ENDPOINT_ENV_VAR] = "AE"
+        env5 = _AstraDBEnvironment()
+        assert env5.async_astra_db.token == "T"
+        assert env5.async_astra_db.api_endpoint == "AE"
+
+        # env vars do not interfere if client(s) passed
+        env6a = _AstraDBEnvironment(
+            async_astra_db_client=Mock(),
+        )
+        env6b = _AstraDBEnvironment(
+            astra_db_client=Mock(),
+        )
+        env6c = _AstraDBEnvironment(
+            astra_db_client=Mock(),
+            async_astra_db_client=Mock(),
+        )
+        assert env6a.astra_db.token != "T"
+        assert env6b.astra_db.token != "T"
+        assert env6c.astra_db.token != "T"
+        assert env6a.astra_db.api_endpoint != "AE"
+        assert env6b.astra_db.api_endpoint != "AE"
+        assert env6c.astra_db.api_endpoint != "AE"
+
+        # env. vars do not interfere if parameters passed
+        env7a = _AstraDBEnvironment(
+            token="t",
+            api_endpoint="ae",
+        )
+        assert env7a.async_astra_db.token == "t"
+        assert env7a.async_astra_db.api_endpoint == "ae"
+        env7b = _AstraDBEnvironment(
+            api_endpoint="ae",
+        )
+        assert env7b.async_astra_db.token == "T"
+        assert env7b.async_astra_db.api_endpoint == "ae"
+        env7c = _AstraDBEnvironment(
+            token="t",
+        )
+        assert env7c.async_astra_db.token == "t"
+        assert env7c.async_astra_db.api_endpoint == "AE"
+
+        # namespaces through env. vars
+        os.environ[NAMESPACE_ENV_VAR] = "NS"
+        env8 = _AstraDBEnvironment(
+            token="t",
+            api_endpoint="ae",
+        )
+        assert env8.astra_db.namespace == "NS"


### PR DESCRIPTION
This PR modifies the flow of the Astra DB environment utils so as to fall back to standard environment variables if Astra DB secrets/connection parameters are required and not provided explicitly.

The presence of such variables in the environment does not alter the current behaviour (except for the case of no namespace provided and one defined in the environment).

An extensive unit test probes the various init combinations.