### PR TITLE
Prepare to release full vectorize support (Bump to 0.3.3)

### DIFF
--- a/libs/astradb/pyproject.toml
+++ b/libs/astradb/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "langchain-astradb"
-version = "0.3.2"
+version = "0.3.3"
 description = "An integration package connecting Astra DB and LangChain"
 authors = []
 readme = "README.md"


### PR DESCRIPTION
Note: This will require astrapy 1.2 or higher, which is a restriction of allowed versions w.r.t. previous releases.