### PR TITLE
fix: add default indexing policy to chat history

### DIFF
--- a/libs/astradb/langchain_astradb/chat_message_histories.py
+++ b/libs/astradb/langchain_astradb/chat_message_histories.py
@@ -18,6 +18,8 @@ from langchain_astradb.utils.astradb import (
     _AstraDBCollectionEnvironment,
 )
 
+# indexing options when creating a collection
+DEFAULT_INDEXING_OPTIONS = {"allow": ["metadata"]}
 DEFAULT_COLLECTION_NAME = "langchain_message_store"
 
 
@@ -63,6 +65,7 @@ class AstraDBChatMessageHistory(BaseChatMessageHistory):
             namespace=namespace,
             setup_mode=setup_mode,
             pre_delete_collection=pre_delete_collection,
+            default_indexing_policy=DEFAULT_COLLECTION_NAME,
         )
 
         self.collection = self.astra_env.collection

--- a/libs/astradb/langchain_astradb/chat_message_histories.py
+++ b/libs/astradb/langchain_astradb/chat_message_histories.py
@@ -65,6 +65,7 @@ class AstraDBChatMessageHistory(BaseChatMessageHistory):
             namespace=namespace,
             setup_mode=setup_mode,
             pre_delete_collection=pre_delete_collection,
+            requested_indexing_policy=DEFAULT_INDEXING_OPTIONS,
             default_indexing_policy=DEFAULT_INDEXING_OPTIONS,
         )
 

--- a/libs/astradb/langchain_astradb/chat_message_histories.py
+++ b/libs/astradb/langchain_astradb/chat_message_histories.py
@@ -65,7 +65,7 @@ class AstraDBChatMessageHistory(BaseChatMessageHistory):
             namespace=namespace,
             setup_mode=setup_mode,
             pre_delete_collection=pre_delete_collection,
-            default_indexing_policy=DEFAULT_COLLECTION_NAME,
+            default_indexing_policy=DEFAULT_INDEXING_OPTIONS,
         )
 
         self.collection = self.astra_env.collection


### PR DESCRIPTION
Adds a default indexing policy to the chat message history class. 

The reason for this is that the default policy when creating a vector store through `AstraDBVectorStore` uses this policy. Meaning, if you create a collection with the class, you cannot initialize chat history, as you'll get this error:

```
E               ValueError: Astra DB collection 'test' is detected as having the following indexing policy: {"allow": ["metadata"]}. This is incompatible with the requested indexing policy for this object. Consider reindexing anew on a fresh collection with the requested indexing policy, or alternatively align the requested indexing settings to the collection to keep using it.

```

I think it makes sense in this case to make the default indexing policy the same here. 

https://github.com/langchain-ai/langchain-datastax/blob/77d3d81d981b9dc28296d85e461b7b803737d904/libs/astradb/langchain_astradb/vectorstores.py#L57