### PR TITLE
All regions have openai vectorize + fix async chat memory test

### DIFF
--- a/libs/astradb/tests/integration_tests/test_vectorstores.py
+++ b/libs/astradb/tests/integration_tests/test_vectorstores.py
@@ -40,10 +40,6 @@ COLLECTION_NAME_VECTORIZE_NVIDIA = "lc_test_nvidia"
 
 MATCH_EPSILON = 0.0001
 
-# For the time being, prod-regions described only
-OPENAI_VECTORIZE_REGIONS_MAP = {
-    "prod": {"us-east-2", "westus3", "us-east1"},  # resp. aws, azure, gcp
-}
 
 openai_vectorize_options = CollectionVectorServiceOptions(
     provider="openai",
@@ -79,14 +75,9 @@ def is_openai_vector_service_available() -> bool:
         env = "prod"
     else:
         env = "other"
-    openai_vectorize_regions = OPENAI_VECTORIZE_REGIONS_MAP.get(env, set())
     return all(
         [
-            any(
-                openai_region in os.environ.get("ASTRA_DB_API_ENDPOINT", "")
-                for openai_region in openai_vectorize_regions
-            ),
-            "astra.datastax.com" in os.environ.get("ASTRA_DB_API_ENDPOINT", ""),
+            env == "prod",
             os.environ.get("SHARED_SECRET_NAME_OPENAI"),
         ]
     )


### PR DESCRIPTION
All regions now have OpenAI among the vectorize providers. This PR:

1. removes the region check for the related OpenAI vectorize tests (both shared_secret and header)
2. tests the specific openai project key created for the CI in this repo

Update: also fixed the fixtures for the "different session IDs" chat memory tests, esp. in the async case. Formerly, both fixtures were trying to create the collection with a (misleading in the message, but still relevant) API error. Now fixture2 depends explicitly on fixture2 (and defers to it for DDL), and the issue seems gone.