### PR TITLE
Add extensive note about "the indexing warning" in README

### DIFF
--- a/libs/astradb/README.md
+++ b/libs/astradb/README.md
@@ -123,4 +123,4 @@ You have several options:
 
 - you can ignore the warning because you know your application will never need to store very long textual contents;
 - you can ignore the warning and explicitly instruct the plugin _not to_ create the collection, assuming it exists already (which suppresses the warning): `store = AstraDBVectorStore(..., setup_mode=langchain_astradb.utils.astradb.SetupMode.OFF)`. In this case the collection will be used as-is, no (indexing) questions asked;
-- if you can afford re-populating the collection anew, you can drop it and re-run the LangChain application: the collection will be created with the optimized indexing settings. **This is the recommended option, when possible**.
+- if you can afford populating the collection anew, you can drop it and re-run the LangChain application: the collection will be created with the optimized indexing settings. **This is the recommended option, when possible**.

--- a/libs/astradb/README.md
+++ b/libs/astradb/README.md
@@ -107,18 +107,20 @@ When creating an Astra DB object in LangChain, such as an `AstraDBVectorStore`, 
 
 > Astra DB collection '...' is detected as having indexing turned on for all fields (either created manually or by older versions of this plugin). This implies stricter limitations on the amount of text each string in a document can store. Consider reindexing anew on a fresh collection to be able to store longer texts.
 
-The reason for the warning is that the requested collection already exists on the database, and it is configured to [index all of its fields for search](https://docs.datastax.com/en/astra-db-serverless/api-reference/collections.html#the-indexing-option), possibly implicitly, by default. When the LangChain object tries to create it, it attempts to enforce, instead, an indexing policy tailored to the prospected usage. For example, the LangChain vector store will index the metadata but leave the textual content out: this is both to enable storing very long texts and to avoid pointless indexing of fields that will never be used in filtering a search.
+The reason for the warning is that the requested collection already exists on the database, and it is configured to [index all of its fields for search](https://docs.datastax.com/en/astra-db-serverless/api-reference/collections.html#the-indexing-option), possibly implicitly, by default. When the LangChain object tries to create it, it attempts to enforce, instead, an indexing policy tailored to the prospected usage. For example, the LangChain vector store will index the metadata but leave the textual content out: this is both to enable storing very long texts and to avoid indexing fields that will never be used in filtering a search (indexing those would also have a slight performance cost for writes).
 
 Typically there are two reasons why you may encounter the warning:
 
-1. you have created a collection by other means than letting the `AstraDBVectorStore` do it for you: for example, through the Astra UI;
-2. you have created the collection with an old version of the Astra DB plugin (i.e. prior to the `langchain-astradb` partner package).
+1. you have created a collection by other means than letting the `AstraDBVectorStore` do it for you: for example, through the Astra UI, or using AstraPy's `create_collection` method of class `Database` directly;
+2. you have created the collection with a version of the Astra DB plugin that is not up-to-date (i.e. prior to the `langchain-astradb` partner package).
 
-Keep in mind that this is a warning and your application will continue running just fine, unless you need to store very long texts.
-For instance, should you need to add, to the vector store, a `Document` whose `page_content` exceeds ~8K in length, you will trigger a database error.
+Keep in mind that this is a warning and your application will continue running just fine, as long as you don't store very long texts.
+Should you need to add to a vector store, for example, a `Document` whose `page_content` exceeds ~8K in length, you will receive an indexing error from the database.
+
+### Remediation
 
 You have several options:
 
 - you can ignore the warning because you know your application will never need to store very long textual contents;
-- you can ignore the warning and explicitly instruct the plugin _not to_ create the collection, assuming it exists already (which suppresses the warning): `store = AstraDBVectorStore(..., setup_mode=langchain_astradb.utils.astradb.SetupMode.OFF)`;
+- you can ignore the warning and explicitly instruct the plugin _not to_ create the collection, assuming it exists already (which suppresses the warning): `store = AstraDBVectorStore(..., setup_mode=langchain_astradb.utils.astradb.SetupMode.OFF)`. In this case the collection will be used as-is, no (indexing) questions asked;
 - if you can afford re-populating the collection anew, you can drop it and re-run the LangChain application: the collection will be created with the optimized indexing settings. **This is the recommended option, when possible**.

--- a/libs/astradb/langchain_astradb/utils/astradb.py
+++ b/libs/astradb/langchain_astradb/utils/astradb.py
@@ -317,8 +317,11 @@ class _AstraDBCollectionEnvironment(_AstraDBEnvironment):
                             "fields (either created manually or by older "
                             "versions of this plugin). This implies stricter "
                             "limitations on the amount of text each string in a "
-                            "document can store. Consider reindexing anew on a "
-                            "fresh collection to be able to store longer texts."
+                            "document can store. Consider indexing anew on a "
+                            "fresh collection to be able to store longer texts. "
+                            "See https://github.com/langchain-ai/langchain-"
+                            "datastax/blob/main/libs/astradb/README.md#"
+                            "warnings-about-indexing for more details."
                         ),
                         UserWarning,
                         stacklevel=2,
@@ -330,7 +333,7 @@ class _AstraDBCollectionEnvironment(_AstraDBEnvironment):
                         "fields (either created manually or by older "
                         "versions of this plugin). This is incompatible with "
                         "the requested indexing policy for this object. "
-                        "Consider reindexing anew on a fresh "
+                        "Consider indexing anew on a fresh "
                         "collection with the requested indexing "
                         "policy, or alternatively leave the indexing "
                         "settings for this object to their defaults "
@@ -348,7 +351,7 @@ class _AstraDBCollectionEnvironment(_AstraDBEnvironment):
                     "detected as having the following indexing policy: "
                     f"{options_json}{default_desc}. This is incompatible "
                     "with the requested indexing policy for this object. "
-                    "Consider reindexing anew on a fresh "
+                    "Consider indexing anew on a fresh "
                     "collection with the requested indexing "
                     "policy, or alternatively align the requested "
                     "indexing settings to the collection to keep using it."


### PR DESCRIPTION
This adds a section about the reason, the origins and the suggested mitigations of the "catch-all indexing" warning that may arise when creating e.g. a vector store with a pre-existing collection created for example in the UI.

We periodically see questions on this very issue, so documenting it here would be a first step. My plan if this verbiage is accepted is to essentially get the same paragraph in LC's docs for greater visibility.
