### PR TITLE
Full porting to astrapy 1.3+

### DIFF
--- a/libs/astradb/langchain_astradb/cache.py
+++ b/libs/astradb/langchain_astradb/cache.py
@@ -3,6 +3,7 @@ import json
 from functools import lru_cache, wraps
 from typing import Any, Awaitable, Callable, Generator, List, Optional, Tuple, Union
 
+from astrapy.authentication import TokenProvider
 from astrapy.db import AstraDB, AsyncAstraDB, logger
 from langchain_core.caches import RETURN_VAL_TYPE, BaseCache
 from langchain_core.embeddings import Embeddings
@@ -93,7 +94,7 @@ class AstraDBCache(BaseCache):
         self,
         *,
         collection_name: str = ASTRA_DB_CACHE_DEFAULT_COLLECTION_NAME,
-        token: Optional[str] = None,
+        token: Optional[Union[str, TokenProvider]] = None,
         api_endpoint: Optional[str] = None,
         environment: Optional[str] = None,
         astra_db_client: Optional[AstraDB] = None,
@@ -113,8 +114,10 @@ class AstraDBCache(BaseCache):
 
         Args:
             collection_name: name of the Astra DB collection to create/use.
-            token: API token for Astra DB usage. If not provided, the environment
-                variable ASTRA_DB_APPLICATION_TOKEN is inspected.
+            token: API token for Astra DB usage, either in the form of a string
+                or a subclass of `astrapy.authentication.TokenProvider`.
+                If not provided, the environment variable
+                ASTRA_DB_APPLICATION_TOKEN is inspected.
             api_endpoint: full URL to the API endpoint, such as
                 `https://<DB-ID>-us-east1.apps.astra.datastax.com`. If not provided,
                 the environment variable ASTRA_DB_API_ENDPOINT is inspected.
@@ -298,7 +301,7 @@ class AstraDBSemanticCache(BaseCache):
         self,
         *,
         collection_name: str = ASTRA_DB_SEMANTIC_CACHE_DEFAULT_COLLECTION_NAME,
-        token: Optional[str] = None,
+        token: Optional[Union[str, TokenProvider]] = None,
         api_endpoint: Optional[str] = None,
         environment: Optional[str] = None,
         astra_db_client: Optional[AstraDB] = None,
@@ -324,8 +327,10 @@ class AstraDBSemanticCache(BaseCache):
 
         Args:
             collection_name: name of the Astra DB collection to create/use.
-            token: API token for Astra DB usage. If not provided, the environment
-                variable ASTRA_DB_APPLICATION_TOKEN is inspected.
+            token: API token for Astra DB usage, either in the form of a string
+                or a subclass of `astrapy.authentication.TokenProvider`.
+                If not provided, the environment variable
+                ASTRA_DB_APPLICATION_TOKEN is inspected.
             api_endpoint: full URL to the API endpoint, such as
                 `https://<DB-ID>-us-east1.apps.astra.datastax.com`. If not provided,
                 the environment variable ASTRA_DB_API_ENDPOINT is inspected.

--- a/libs/astradb/langchain_astradb/cache.py
+++ b/libs/astradb/langchain_astradb/cache.py
@@ -170,15 +170,13 @@ class AstraDBCache(BaseCache):
     async def alookup(self, prompt: str, llm_string: str) -> Optional[RETURN_VAL_TYPE]:
         await self.astra_env.aensure_db_setup()
         doc_id = self._make_id(prompt, llm_string)
-        item = (
-            await self.async_collection.find_one(
-                filter={
-                    "_id": doc_id,
-                },
-                projection={
-                    "body_blob": 1,
-                },
-            )
+        item = await self.async_collection.find_one(
+            filter={
+                "_id": doc_id,
+            },
+            projection={
+                "body_blob": 1,
+            },
         )
         return _loads_generations(item["body_blob"]) if item is not None else None
 

--- a/libs/astradb/langchain_astradb/chat_message_histories.py
+++ b/libs/astradb/langchain_astradb/chat_message_histories.py
@@ -3,8 +3,9 @@ from __future__ import annotations
 
 import json
 import time
-from typing import List, Optional, Sequence
+from typing import List, Optional, Sequence, Union
 
+from astrapy.authentication import TokenProvider
 from astrapy.db import AstraDB, AsyncAstraDB
 from langchain_core.chat_history import BaseChatMessageHistory
 from langchain_core.messages import (
@@ -27,7 +28,7 @@ class AstraDBChatMessageHistory(BaseChatMessageHistory):
         *,
         session_id: str,
         collection_name: str = DEFAULT_COLLECTION_NAME,
-        token: Optional[str] = None,
+        token: Optional[Union[str, TokenProvider]] = None,
         api_endpoint: Optional[str] = None,
         environment: Optional[str] = None,
         astra_db_client: Optional[AstraDB] = None,
@@ -42,8 +43,10 @@ class AstraDBChatMessageHistory(BaseChatMessageHistory):
             session_id: arbitrary key that is used to store the messages
                 of a single chat session.
             collection_name: name of the Astra DB collection to create/use.
-            token: API token for Astra DB usage. If not provided, the environment
-                variable ASTRA_DB_APPLICATION_TOKEN is inspected.
+            token: API token for Astra DB usage, either in the form of a string
+                or a subclass of `astrapy.authentication.TokenProvider`.
+                If not provided, the environment variable
+                ASTRA_DB_APPLICATION_TOKEN is inspected.
             api_endpoint: full URL to the API endpoint, such as
                 `https://<DB-ID>-us-east1.apps.astra.datastax.com`. If not provided,
                 the environment variable ASTRA_DB_API_ENDPOINT is inspected.

--- a/libs/astradb/langchain_astradb/document_loaders.py
+++ b/libs/astradb/langchain_astradb/document_loaders.py
@@ -44,7 +44,7 @@ class AstraDBLoader(BaseLoader):
         projection: Optional[Dict[str, Any]] = _NOT_SET,  # type: ignore[assignment]
         find_options: Optional[Dict[str, Any]] = None,
         limit: Optional[int] = None,
-        nb_prefetched: int = 1000,
+        nb_prefetched: int = _NOT_SET,  # type: ignore[assignment]
         page_content_mapper: Callable[[Dict], str] = json.dumps,
         metadata_mapper: Optional[Callable[[Dict], Dict[str, Any]]] = None,
     ) -> None:
@@ -82,7 +82,8 @@ class AstraDBLoader(BaseLoader):
                 *DEPRECATED starting from version 0.3.5.*
                 *For limiting, please use `limit`. Other options are ignored.*
             limit: a maximum number of documents to return in the read query.
-            nb_prefetched: Max number of documents to pre-fetch. Defaults to 1000.
+            nb_prefetched: Max number of documents to pre-fetch.
+                *IGNORED starting from v. 0.3.5: astrapy v1.0+ does not support it.*
             page_content_mapper: Function applied to collection documents to create
                 the `page_content` of the LangChain Document. Defaults to `json.dumps`.
         """
@@ -101,6 +102,16 @@ class AstraDBLoader(BaseLoader):
         self._projection: Optional[Dict[str, Any]] = (
             projection if projection is not _NOT_SET else {"*": True}
         )
+        # warning if 'prefetched' passed
+        if nb_prefetched is not _NOT_SET:
+            warnings.warn(
+                (
+                    "Parameter 'nb_prefetched' is not supported by the Data API "
+                    "client and will be ignored in reading document."
+                ),
+                UserWarning,
+            )
+
         # normalizing limit and options and deprecations
         _limit: Optional[int]
         if "limit" in (find_options or {}):

--- a/libs/astradb/langchain_astradb/document_loaders.py
+++ b/libs/astradb/langchain_astradb/document_loaders.py
@@ -118,7 +118,7 @@ class AstraDBLoader(BaseLoader):
                 _limit = (find_options or {})["limit"]
         else:
             _limit = limit
-        self.limit =_limit
+        self.limit = _limit
         _other_option_keys = set((find_options or {}).keys()) - {"limit"}
         if _other_option_keys:
             warnings.warn(

--- a/libs/astradb/langchain_astradb/document_loaders.py
+++ b/libs/astradb/langchain_astradb/document_loaders.py
@@ -11,8 +11,10 @@ from typing import (
     Iterator,
     List,
     Optional,
+    Union,
 )
 
+from astrapy.authentication import TokenProvider
 from astrapy.db import AstraDB, AsyncAstraDB
 from langchain_core.document_loaders import BaseLoader
 from langchain_core.documents import Document
@@ -32,7 +34,7 @@ class AstraDBLoader(BaseLoader):
         self,
         collection_name: str,
         *,
-        token: Optional[str] = None,
+        token: Optional[Union[str, TokenProvider]] = None,
         api_endpoint: Optional[str] = None,
         environment: Optional[str] = None,
         astra_db_client: Optional[AstraDB] = None,
@@ -50,8 +52,10 @@ class AstraDBLoader(BaseLoader):
 
         Args:
             collection_name: name of the Astra DB collection to use.
-            token: API token for Astra DB usage. If not provided, the environment
-                variable ASTRA_DB_APPLICATION_TOKEN is inspected.
+            token: API token for Astra DB usage, either in the form of a string
+                or a subclass of `astrapy.authentication.TokenProvider`.
+                If not provided, the environment variable
+                ASTRA_DB_APPLICATION_TOKEN is inspected.
             api_endpoint: full URL to the API endpoint, such as
                 `https://<DB-ID>-us-east1.apps.astra.datastax.com`. If not provided,
                 the environment variable ASTRA_DB_API_ENDPOINT is inspected.

--- a/libs/astradb/langchain_astradb/document_loaders.py
+++ b/libs/astradb/langchain_astradb/document_loaders.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import logging
+import warnings
 from typing import (
     Any,
     AsyncIterator,
@@ -33,12 +34,14 @@ class AstraDBLoader(BaseLoader):
         *,
         token: Optional[str] = None,
         api_endpoint: Optional[str] = None,
+        environment: Optional[str] = None,
         astra_db_client: Optional[AstraDB] = None,
         async_astra_db_client: Optional[AsyncAstraDB] = None,
         namespace: Optional[str] = None,
         filter_criteria: Optional[Dict[str, Any]] = None,
         projection: Optional[Dict[str, Any]] = _NOT_SET,  # type: ignore[assignment]
         find_options: Optional[Dict[str, Any]] = None,
+        limit: Optional[int] = None,
         nb_prefetched: int = 1000,
         page_content_mapper: Callable[[Dict], str] = json.dumps,
         metadata_mapper: Optional[Callable[[Dict], Dict[str, Any]]] = None,
@@ -52,10 +55,19 @@ class AstraDBLoader(BaseLoader):
             api_endpoint: full URL to the API endpoint, such as
                 `https://<DB-ID>-us-east1.apps.astra.datastax.com`. If not provided,
                 the environment variable ASTRA_DB_API_ENDPOINT is inspected.
-            astra_db_client: *alternative to token+api_endpoint*,
-                you can pass an already-created 'astrapy.db.AstraDB' instance.
-            async_astra_db_client: *alternative to token+api_endpoint*,
-                you can pass an already-created 'astrapy.db.AsyncAstraDB' instance.
+            environment: a string specifying the environment of the target Data API.
+                If omitted, defaults to "prod" (Astra DB production).
+                Other values are in `astrapy.constants.Environment` enum class.
+            astra_db_client:
+                *DEPRECATED starting from version 0.3.5.*
+                *Please use 'token', 'api_endpoint' and optionally 'environment'.*
+                you can pass an already-created 'astrapy.db.AstraDB' instance
+                (alternatively to 'token', 'api_endpoint' and 'environment').
+            async_astra_db_client:
+                *DEPRECATED starting from version 0.3.5.*
+                *Please use 'token', 'api_endpoint' and optionally 'environment'.*
+                you can pass an already-created 'astrapy.db.AsyncAstraDB' instance
+                (alternatively to 'token', 'api_endpoint' and 'environment').
             namespace: namespace (aka keyspace) where the collection resides.
                 If not provided, the environment variable ASTRA_DB_KEYSPACE is
                 inspected. Defaults to the database's "default namespace".
@@ -63,6 +75,9 @@ class AstraDBLoader(BaseLoader):
             projection: Specifies the fields to return. If not provided, reads
                 fall back to the Data API default projection.
             find_options: Additional options for the query.
+                *DEPRECATED starting from version 0.3.5.*
+                *For limiting, please use `limit`. Other options are ignored.*
+            limit: a maximum number of documents to return in the read query.
             nb_prefetched: Max number of documents to pre-fetch. Defaults to 1000.
             page_content_mapper: Function applied to collection documents to create
                 the `page_content` of the LangChain Document. Defaults to `json.dumps`.
@@ -71,6 +86,7 @@ class AstraDBLoader(BaseLoader):
             collection_name=collection_name,
             token=token,
             api_endpoint=api_endpoint,
+            environment=environment,
             astra_db_client=astra_db_client,
             async_astra_db_client=async_astra_db_client,
             namespace=namespace,
@@ -81,13 +97,44 @@ class AstraDBLoader(BaseLoader):
         self._projection: Optional[Dict[str, Any]] = (
             projection if projection is not _NOT_SET else {"*": True}
         )
-        self.find_options = find_options or {}
+        # normalizing limit and options and deprecations
+        _limit: Optional[int]
+        if "limit" in (find_options or {}):
+            if limit is not None:
+                raise ValueError(
+                    "Duplicate 'limit' directive supplied. Please remove it "
+                    "from the 'find_options' map parameter."
+                )
+            else:
+                warnings.warn(
+                    (
+                        "Passing 'limit' as part of the 'find_options' "
+                        "dictionary is deprecated starting from version 0.3.5. "
+                        "Please switch to passing 'limit=<number>' "
+                        "directly in the constructor."
+                    ),
+                    DeprecationWarning,
+                )
+                _limit = (find_options or {})["limit"]
+        else:
+            _limit = limit
+        self.limit =_limit
+        _other_option_keys = set((find_options or {}).keys()) - {"limit"}
+        if _other_option_keys:
+            warnings.warn(
+                (
+                    "Unknown keys passed in the 'find_options' dictionary. "
+                    "This parameter is deprecated starting from version 0.3.5."
+                ),
+                DeprecationWarning,
+            )
+        #
         self.nb_prefetched = nb_prefetched
         self.page_content_mapper = page_content_mapper
         self.metadata_mapper = metadata_mapper or (
             lambda _: {
-                "namespace": self.astra_db_env.astra_db.namespace,
-                "api_endpoint": self.astra_db_env.astra_db.base_url,
+                "namespace": self.astra_db_env.database.namespace,
+                "api_endpoint": self.astra_db_env.database.api_endpoint,
                 "collection": collection_name,
             }
         )
@@ -99,12 +146,12 @@ class AstraDBLoader(BaseLoader):
         )
 
     def lazy_load(self) -> Iterator[Document]:
-        for doc in self.astra_db_env.collection.paginated_find(
+        for doc in self.astra_db_env.collection.find(
             filter=self.filter,
-            options=self.find_options,
             projection=self._projection,
-            sort=None,
-            prefetched=self.nb_prefetched,
+            limit=self.limit,
+            # prefetch: not available at the moment (silently ignored)
+            # prefetched=self.nb_prefetched,
         ):
             yield self._to_langchain_doc(doc)
 
@@ -113,11 +160,11 @@ class AstraDBLoader(BaseLoader):
         return [doc async for doc in self.alazy_load()]
 
     async def alazy_load(self) -> AsyncIterator[Document]:
-        async for doc in self.astra_db_env.async_collection.paginated_find(
+        async for doc in self.astra_db_env.async_collection.find(
             filter=self.filter,
-            options=self.find_options,
             projection=self._projection,
-            sort=None,
-            prefetched=self.nb_prefetched,
+            limit=self.limit,
+            # prefetch: not available at the moment (silently ignored):
+            # prefetched=self.nb_prefetched,
         ):
             yield self._to_langchain_doc(doc)

--- a/libs/astradb/langchain_astradb/storage.py
+++ b/libs/astradb/langchain_astradb/storage.py
@@ -15,8 +15,10 @@ from typing import (
     Sequence,
     Tuple,
     TypeVar,
+    Union,
 )
 
+from astrapy.authentication import TokenProvider
 from astrapy.db import AstraDB, AsyncAstraDB
 from astrapy.exceptions import InsertManyException
 from astrapy.results import UpdateResult
@@ -220,7 +222,7 @@ class AstraDBStore(AstraDBBaseStore[Any]):
         self,
         collection_name: str,
         *,
-        token: Optional[str] = None,
+        token: Optional[Union[str, TokenProvider]] = None,
         api_endpoint: Optional[str] = None,
         environment: Optional[str] = None,
         astra_db_client: Optional[AstraDB] = None,
@@ -244,8 +246,10 @@ class AstraDBStore(AstraDBBaseStore[Any]):
 
         Args:
             collection_name: name of the Astra DB collection to create/use.
-            token: API token for Astra DB usage. If not provided, the environment
-                variable ASTRA_DB_APPLICATION_TOKEN is inspected.
+            token: API token for Astra DB usage, either in the form of a string
+                or a subclass of `astrapy.authentication.TokenProvider`.
+                If not provided, the environment variable
+                ASTRA_DB_APPLICATION_TOKEN is inspected.
             api_endpoint: full URL to the API endpoint, such as
                 `https://<DB-ID>-us-east1.apps.astra.datastax.com`. If not provided,
                 the environment variable ASTRA_DB_API_ENDPOINT is inspected.
@@ -295,7 +299,7 @@ class AstraDBByteStore(AstraDBBaseStore[bytes], ByteStore):
         self,
         *,
         collection_name: str,
-        token: Optional[str] = None,
+        token: Optional[Union[str, TokenProvider]] = None,
         api_endpoint: Optional[str] = None,
         environment: Optional[str] = None,
         astra_db_client: Optional[AstraDB] = None,
@@ -317,8 +321,10 @@ class AstraDBByteStore(AstraDBBaseStore[bytes], ByteStore):
 
         Args:
             collection_name: name of the Astra DB collection to create/use.
-            token: API token for Astra DB usage. If not provided, the environment
-                variable ASTRA_DB_APPLICATION_TOKEN is inspected.
+            token: API token for Astra DB usage, either in the form of a string
+                or a subclass of `astrapy.authentication.TokenProvider`.
+                If not provided, the environment variable
+                ASTRA_DB_APPLICATION_TOKEN is inspected.
             api_endpoint: full URL to the API endpoint, such as
                 `https://<DB-ID>-us-east1.apps.astra.datastax.com`. If not provided,
                 the environment variable ASTRA_DB_API_ENDPOINT is inspected.

--- a/libs/astradb/langchain_astradb/storage.py
+++ b/libs/astradb/langchain_astradb/storage.py
@@ -26,7 +26,7 @@ V = TypeVar("V")
 
 
 class AstraDBBaseStore(Generic[V], BaseStore[str, V], ABC):
-    """Base class for the DataStax AstraDB data store."""
+    """Base class for the DataStax Astra DB data store."""
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         if "requested_indexing_policy" in kwargs:

--- a/libs/astradb/langchain_astradb/storage.py
+++ b/libs/astradb/langchain_astradb/storage.py
@@ -23,9 +23,9 @@ from astrapy.results import UpdateResult
 from langchain_core.stores import BaseStore, ByteStore
 
 from langchain_astradb.utils.astradb import (
+    REPLACE_DOCUMENTS_MAX_THREADS,
     SetupMode,
     _AstraDBCollectionEnvironment,
-    REPLACE_DOCUMENTS_MAX_THREADS,
 )
 
 V = TypeVar("V")

--- a/libs/astradb/langchain_astradb/utils/astradb.py
+++ b/libs/astradb/langchain_astradb/utils/astradb.py
@@ -87,21 +87,27 @@ class _AstraDBEnvironment:
                 ),
                 DeprecationWarning,
             )
-            _tokens = list({
-                klient.token
-                for klient in [astra_db_client, async_astra_db_client]
-                if klient is not None
-            })
-            _api_endpoints = list({
-                klient.api_endpoint
-                for klient in [astra_db_client, async_astra_db_client]
-                if klient is not None
-            })
-            _namespaces = list({
-                klient.namespace
-                for klient in [astra_db_client, async_astra_db_client]
-                if klient is not None
-            })
+            _tokens = list(
+                {
+                    klient.token
+                    for klient in [astra_db_client, async_astra_db_client]
+                    if klient is not None
+                }
+            )
+            _api_endpoints = list(
+                {
+                    klient.api_endpoint
+                    for klient in [astra_db_client, async_astra_db_client]
+                    if klient is not None
+                }
+            )
+            _namespaces = list(
+                {
+                    klient.namespace
+                    for klient in [astra_db_client, async_astra_db_client]
+                    if klient is not None
+                }
+            )
             if len(_tokens) != 1:
                 raise ValueError(
                     "Conflicting tokens found in the sync and async AstraDB "
@@ -163,8 +169,8 @@ class _AstraDBEnvironment:
             )
 
         # create the clients
-        caller_name="langchain"
-        caller_version=getattr(langchain_core, "__version__", None)
+        caller_name = "langchain"
+        caller_version = getattr(langchain_core, "__version__", None)
 
         self.data_api_client = DataAPIClient(
             environment=self.environment,
@@ -217,7 +223,6 @@ class _AstraDBCollectionEnvironment(_AstraDBEnvironment):
 
         self.async_setup_db_task: Optional[Task] = None
         if setup_mode == SetupMode.ASYNC:
-
             async_database = self.async_database
 
             async def _setup_db() -> None:
@@ -286,7 +291,6 @@ class _AstraDBCollectionEnvironment(_AstraDBEnvironment):
                     ):
                         # other reasons for the exception
                         raise
-
 
     @staticmethod
     def _validate_indexing_policy(

--- a/libs/astradb/langchain_astradb/utils/astradb.py
+++ b/libs/astradb/langchain_astradb/utils/astradb.py
@@ -235,7 +235,7 @@ class _AstraDBCollectionEnvironment(_AstraDBEnvironment):
                     # or custom, indexing settings: verify
                     collection_descriptors = [
                         coll_desc
-                        async for coll_desc in await async_database.list_collections()
+                        async for coll_desc in async_database.list_collections()
                     ]
                     if not self._validate_indexing_policy(
                         collection_descriptors=collection_descriptors,

--- a/libs/astradb/langchain_astradb/utils/astradb.py
+++ b/libs/astradb/langchain_astradb/utils/astradb.py
@@ -20,7 +20,7 @@ TOKEN_ENV_VAR = "ASTRA_DB_APPLICATION_TOKEN"
 API_ENDPOINT_ENV_VAR = "ASTRA_DB_API_ENDPOINT"
 NAMESPACE_ENV_VAR = "ASTRA_DB_KEYSPACE"
 
-DEFAULT_VECTORIZE_SECRET_HEADER = "x-embedding-api-key"
+REPLACE_DOCUMENTS_MAX_THREADS = 20
 
 logger = logging.getLogger()
 
@@ -205,10 +205,7 @@ class _AstraDBCollectionEnvironment(_AstraDBEnvironment):
             name=self.collection_name,
             embedding_api_key=collection_embedding_api_key,
         )
-        self.async_collection = self.database.get_collection(
-            name=self.collection_name,
-            embedding_api_key=collection_embedding_api_key,
-        )
+        self.async_collection = self.collection.to_async()
 
         self.async_setup_db_task: Optional[Task] = None
         if setup_mode == SetupMode.ASYNC:

--- a/libs/astradb/langchain_astradb/utils/astradb.py
+++ b/libs/astradb/langchain_astradb/utils/astradb.py
@@ -20,7 +20,15 @@ TOKEN_ENV_VAR = "ASTRA_DB_APPLICATION_TOKEN"
 API_ENDPOINT_ENV_VAR = "ASTRA_DB_API_ENDPOINT"
 NAMESPACE_ENV_VAR = "ASTRA_DB_KEYSPACE"
 
+# Default settings for API data operations (concurrency & similar):
+# Chunk size for many-document insertions (None meaning defer to astrapy):
+DEFAULT_DOCUMENT_CHUNK_SIZE = None
+# thread/coroutine count for bulk inserts
+INSERT_DOCUMENT_MAX_THREADS = 20
+# Thread/coroutine count for one-doc-at-a-time overwrites
 REPLACE_DOCUMENTS_MAX_THREADS = 20
+# Thread/coroutine count for one-doc-at-a-time deletes:
+DELETE_DOCUMENTS_MAX_THREADS = 20
 
 logger = logging.getLogger()
 

--- a/libs/astradb/langchain_astradb/utils/astradb.py
+++ b/libs/astradb/langchain_astradb/utils/astradb.py
@@ -12,6 +12,7 @@ from typing import Any, Awaitable, Dict, List, Optional, Union
 
 import langchain_core
 from astrapy import AsyncDatabase, DataAPIClient, Database
+from astrapy.authentication import EmbeddingHeadersProvider, TokenProvider
 from astrapy.db import AstraDB, AsyncAstraDB  # 'core' astrapy imports
 from astrapy.exceptions import DataAPIException
 from astrapy.info import CollectionDescriptor, CollectionVectorServiceOptions
@@ -42,14 +43,14 @@ class SetupMode(Enum):
 class _AstraDBEnvironment:
     def __init__(
         self,
-        token: Optional[str] = None,
+        token: Optional[Union[str, TokenProvider]] = None,
         api_endpoint: Optional[str] = None,
         environment: Optional[str] = None,
         astra_db_client: Optional[AstraDB] = None,
         async_astra_db_client: Optional[AsyncAstraDB] = None,
         namespace: Optional[str] = None,
     ) -> None:
-        self.token: Optional[str]
+        self.token: Optional[Union[str, TokenProvider]]
         self.api_endpoint: Optional[str]
         self.namespace: Optional[str]
         self.environment: Optional[str]
@@ -131,6 +132,7 @@ class _AstraDBEnvironment:
             self.api_endpoint = _api_endpoints[0]
             self.namespace = _namespaces[0]
         else:
+            _token: Optional[Union[str, TokenProvider]]
             # secrets-based initialization
             if token is None:
                 logger.info(
@@ -189,7 +191,7 @@ class _AstraDBCollectionEnvironment(_AstraDBEnvironment):
     def __init__(
         self,
         collection_name: str,
-        token: Optional[str] = None,
+        token: Optional[Union[str, TokenProvider]] = None,
         api_endpoint: Optional[str] = None,
         environment: Optional[str] = None,
         astra_db_client: Optional[AstraDB] = None,
@@ -204,7 +206,9 @@ class _AstraDBCollectionEnvironment(_AstraDBEnvironment):
         collection_vector_service_options: Optional[
             CollectionVectorServiceOptions
         ] = None,
-        collection_embedding_api_key: Optional[str] = None,
+        collection_embedding_api_key: Optional[
+            Union[str, EmbeddingHeadersProvider]
+        ] = None,
     ) -> None:
         super().__init__(
             token=token,

--- a/libs/astradb/langchain_astradb/vectorstores.py
+++ b/libs/astradb/langchain_astradb/vectorstores.py
@@ -294,8 +294,7 @@ class AstraDBVectorStore(VectorStore):
             bulk_insert_batch_concurrency or INSERT_DOCUMENT_MAX_THREADS
         )
         self.bulk_insert_overwrite_concurrency: int = (
-            bulk_insert_overwrite_concurrency
-            or REPLACE_DOCUMENTS_MAX_THREADS
+            bulk_insert_overwrite_concurrency or REPLACE_DOCUMENTS_MAX_THREADS
         )
         self.bulk_delete_concurrency: int = (
             bulk_delete_concurrency or DELETE_DOCUMENTS_MAX_THREADS
@@ -701,9 +700,11 @@ class AstraDBVectorStore(VectorStore):
                         document,
                     ), document["_id"]
 
-                replace_results = executor.map(
-                    _replace_document,
-                    documents_to_replace,
+                replace_results = list(
+                    executor.map(
+                        _replace_document,
+                        documents_to_replace,
+                    )
                 )
 
             replaced_count = sum(r_res.update_info["n"] for r_res, _ in replace_results)
@@ -810,6 +811,7 @@ class AstraDBVectorStore(VectorStore):
             )
 
             _async_collection = self.astra_env.async_collection
+
             async def _replace_document(
                 document: Dict[str, Any],
             ) -> Tuple[UpdateResult, str]:
@@ -820,9 +822,7 @@ class AstraDBVectorStore(VectorStore):
                     ), document["_id"]
 
             tasks = [
-                asyncio.create_task(
-                    _replace_document(document)
-                )
+                asyncio.create_task(_replace_document(document))
                 for document in documents_to_replace
             ]
 

--- a/libs/astradb/pyproject.toml
+++ b/libs/astradb/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "langchain-astradb"
-version = "0.3.4"
+version = "0.3.5"
 description = "An integration package connecting Astra DB and LangChain"
 authors = []
 readme = "README.md"

--- a/libs/astradb/pyproject.toml
+++ b/libs/astradb/pyproject.toml
@@ -13,7 +13,7 @@ license = "MIT"
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"
 langchain-core = ">=0.1.31,<0.3"
-astrapy = "^1.3"
+astrapy = "^1.4"
 numpy = "^1"
 
 [tool.poetry.group.test]

--- a/libs/astradb/testing.env.sample
+++ b/libs/astradb/testing.env.sample
@@ -7,5 +7,5 @@ export SHARED_SECRET_NAME_OPENAI="NAME_SUPPLIED_IN_ASTRA_KMS"
 # required to test vectorize with HEADER
 export OPENAI_API_KEY="sk-aaabbbccc..."
 
-# Also invoke pytest prepending `NVIDIA_VECTORIZE_AVAILABLE=1` if
-# the database supports server-side nVidia embeddings as well
+# change to "1" if nvidia server-side embeddings are available for the DB
+export NVIDIA_VECTORIZE_AVAILABLE="0"

--- a/libs/astradb/testing.env.sample
+++ b/libs/astradb/testing.env.sample
@@ -1,8 +1,10 @@
 export ASTRA_DB_APPLICATION_TOKEN="AstraCS:aaabbbccc..."
 export ASTRA_DB_API_ENDPOINT="https://0123...-region.apps.astra.datastax.com"
 export ASTRA_DB_KEYSPACE="default_keyspace"
+# Optional (mostly for HCD and such):
+# export ASTRA_DB_ENVIRONMENT="..."
 
-# required to test vectorize with SHARED_SECRET
+# required to test vectorize with SHARED_SECRET. Comment on HCD and such.
 export SHARED_SECRET_NAME_OPENAI="NAME_SUPPLIED_IN_ASTRA_KMS"
 # required to test vectorize with HEADER
 export OPENAI_API_KEY="sk-aaabbbccc..."

--- a/libs/astradb/tests/conftest.py
+++ b/libs/astradb/tests/conftest.py
@@ -1,0 +1,65 @@
+"""
+General-purpose testing tools, such as:
+    - Ad-hoc embedding classes
+"""
+
+import json
+from typing import List
+
+from langchain_core.embeddings import Embeddings
+
+
+class SomeEmbeddings(Embeddings):
+    """
+    Turn a sentence into an embedding vector in some way.
+    Not important how. It is deterministic is all that counts.
+    """
+
+    def __init__(self, dimension: int) -> None:
+        self.dimension = dimension
+
+    def embed_documents(self, texts: List[str]) -> List[List[float]]:
+        return [self.embed_query(txt) for txt in texts]
+
+    async def aembed_documents(self, texts: List[str]) -> List[List[float]]:
+        return self.embed_documents(texts)
+
+    def embed_query(self, text: str) -> List[float]:
+        unnormed0 = [ord(c) for c in text[: self.dimension]]
+        unnormed = (unnormed0 + [1] + [0] * (self.dimension - 1 - len(unnormed0)))[
+            : self.dimension
+        ]
+        norm = sum(x * x for x in unnormed) ** 0.5
+        normed = [x / norm for x in unnormed]
+        return normed
+
+    async def aembed_query(self, text: str) -> List[float]:
+        return self.embed_query(text)
+
+
+class ParserEmbeddings(Embeddings):
+    """
+    Parse input texts: if they are json for a List[float], fine.
+    Otherwise, return all zeros and call it a day.
+    """
+
+    def __init__(self, dimension: int) -> None:
+        self.dimension = dimension
+
+    def embed_documents(self, texts: List[str]) -> List[List[float]]:
+        return [self.embed_query(txt) for txt in texts]
+
+    async def aembed_documents(self, texts: List[str]) -> List[List[float]]:
+        return self.embed_documents(texts)
+
+    def embed_query(self, text: str) -> List[float]:
+        try:
+            vals = json.loads(text)
+            assert len(vals) == self.dimension
+            return vals
+        except Exception:
+            print(f'[ParserEmbeddings] Returning a moot vector for "{text}"')
+            return [0.0] * self.dimension
+
+    async def aembed_query(self, text: str) -> List[float]:
+        return self.embed_query(text)

--- a/libs/astradb/tests/integration_tests/conftest.py
+++ b/libs/astradb/tests/integration_tests/conftest.py
@@ -1,6 +1,11 @@
-# Getting the absolute path of the current file's directory
 import os
+from typing import Dict, Optional
 
+import pytest
+from astrapy import Database
+from astrapy.db import AstraDB
+
+# Getting the absolute path of the current file's directory
 ABS_PATH = os.path.dirname(os.path.abspath(__file__))
 
 # Getting the absolute path of the project's root directory
@@ -14,6 +19,44 @@ def _load_env() -> None:
         from dotenv import load_dotenv
 
         load_dotenv(dotenv_path)
+
+
+def _has_env_vars() -> bool:
+    return all(
+        [
+            "ASTRA_DB_APPLICATION_TOKEN" in os.environ,
+            "ASTRA_DB_API_ENDPOINT" in os.environ,
+        ]
+    )
+
+
+@pytest.fixture(scope="session")
+def astra_db_credentials() -> Dict[str, Optional[str]]:
+    return {
+        "token": os.environ["ASTRA_DB_APPLICATION_TOKEN"],
+        "api_endpoint": os.environ["ASTRA_DB_API_ENDPOINT"],
+        "namespace": os.environ.get("ASTRA_DB_KEYSPACE"),
+        "environment": os.environ.get("ASTRA_DB_ENVIRONMENT"),
+    }
+
+
+@pytest.fixture(scope="session")
+def database(astra_db_credentials: Dict[str, Optional[str]]) -> Database:
+    return Database(
+        token=astra_db_credentials["token"],
+        api_endpoint=astra_db_credentials["api_endpoint"],  # type: ignore[arg-type]
+        namespace=astra_db_credentials["namespace"],
+        environment=astra_db_credentials["environment"],
+    )
+
+
+@pytest.fixture(scope="session")
+def core_astra_db(astra_db_credentials: Dict[str, Optional[str]]) -> AstraDB:
+    return AstraDB(
+        token=astra_db_credentials["token"],
+        api_endpoint=astra_db_credentials["api_endpoint"],  # type: ignore[arg-type]
+        namespace=astra_db_credentials["namespace"],
+    )
 
 
 _load_env()

--- a/libs/astradb/tests/integration_tests/conftest.py
+++ b/libs/astradb/tests/integration_tests/conftest.py
@@ -1,5 +1,5 @@
 import os
-from typing import Dict, Optional, TypedDict
+from typing import Optional, TypedDict
 
 import pytest
 from astrapy import Database

--- a/libs/astradb/tests/integration_tests/conftest.py
+++ b/libs/astradb/tests/integration_tests/conftest.py
@@ -1,5 +1,5 @@
 import os
-from typing import Dict, Optional
+from typing import Dict, Optional, TypedDict
 
 import pytest
 from astrapy import Database
@@ -30,8 +30,15 @@ def _has_env_vars() -> bool:
     )
 
 
+class AstraDBCredentials(TypedDict):
+    token: str
+    api_endpoint: str
+    namespace: Optional[str]
+    environment: Optional[str]
+
+
 @pytest.fixture(scope="session")
-def astra_db_credentials() -> Dict[str, Optional[str]]:
+def astra_db_credentials() -> AstraDBCredentials:
     return {
         "token": os.environ["ASTRA_DB_APPLICATION_TOKEN"],
         "api_endpoint": os.environ["ASTRA_DB_API_ENDPOINT"],
@@ -41,7 +48,7 @@ def astra_db_credentials() -> Dict[str, Optional[str]]:
 
 
 @pytest.fixture(scope="session")
-def database(astra_db_credentials: Dict[str, Optional[str]]) -> Database:
+def database(astra_db_credentials: AstraDBCredentials) -> Database:
     return Database(
         token=astra_db_credentials["token"],
         api_endpoint=astra_db_credentials["api_endpoint"],  # type: ignore[arg-type]
@@ -51,7 +58,7 @@ def database(astra_db_credentials: Dict[str, Optional[str]]) -> Database:
 
 
 @pytest.fixture(scope="session")
-def core_astra_db(astra_db_credentials: Dict[str, Optional[str]]) -> AstraDB:
+def core_astra_db(astra_db_credentials: AstraDBCredentials) -> AstraDB:
     return AstraDB(
         token=astra_db_credentials["token"],
         api_endpoint=astra_db_credentials["api_endpoint"],  # type: ignore[arg-type]

--- a/libs/astradb/tests/integration_tests/test_caches.py
+++ b/libs/astradb/tests/integration_tests/test_caches.py
@@ -107,9 +107,7 @@ class FakeLLM(LLM):
 
 
 @pytest.fixture(scope="module")
-def astradb_cache(
-    astra_db_credentials: AstraDBCredentials
-) -> Iterator[AstraDBCache]:
+def astradb_cache(astra_db_credentials: AstraDBCredentials) -> Iterator[AstraDBCache]:
     cache = AstraDBCache(
         collection_name="lc_integration_test_cache",
         token=astra_db_credentials["token"],
@@ -123,7 +121,7 @@ def astradb_cache(
 
 @pytest.fixture(scope="function")
 async def async_astradb_cache(
-    astra_db_credentials: AstraDBCredentials
+    astra_db_credentials: AstraDBCredentials,
 ) -> AsyncIterator[AstraDBCache]:
     cache = AstraDBCache(
         collection_name="lc_integration_test_cache_async",
@@ -139,7 +137,7 @@ async def async_astradb_cache(
 
 @pytest.fixture(scope="module")
 def astradb_semantic_cache(
-    astra_db_credentials: AstraDBCredentials
+    astra_db_credentials: AstraDBCredentials,
 ) -> Iterator[AstraDBSemanticCache]:
     fake_embe = FakeEmbeddings()
     sem_cache = AstraDBSemanticCache(
@@ -156,7 +154,7 @@ def astradb_semantic_cache(
 
 @pytest.fixture(scope="function")
 async def async_astradb_semantic_cache(
-    astra_db_credentials: AstraDBCredentials
+    astra_db_credentials: AstraDBCredentials,
 ) -> AsyncIterator[AstraDBSemanticCache]:
     fake_embe = FakeEmbeddings()
     sem_cache = AstraDBSemanticCache(

--- a/libs/astradb/tests/integration_tests/test_caches.py
+++ b/libs/astradb/tests/integration_tests/test_caches.py
@@ -27,7 +27,7 @@ from langchain_core.pydantic_v1 import validator
 from langchain_astradb import AstraDBCache, AstraDBSemanticCache
 from langchain_astradb.utils.astradb import SetupMode
 
-from .conftest import _has_env_vars
+from .conftest import _has_env_vars, AstraDBCredentials
 
 
 class FakeEmbeddings(Embeddings):
@@ -108,7 +108,7 @@ class FakeLLM(LLM):
 
 @pytest.fixture(scope="module")
 def astradb_cache(
-    astra_db_credentials: Dict[str, Optional[str]]
+    astra_db_credentials: AstraDBCredentials
 ) -> Iterator[AstraDBCache]:
     cache = AstraDBCache(
         collection_name="lc_integration_test_cache",
@@ -123,7 +123,7 @@ def astradb_cache(
 
 @pytest.fixture(scope="function")
 async def async_astradb_cache(
-    astra_db_credentials: Dict[str, Optional[str]]
+    astra_db_credentials: AstraDBCredentials
 ) -> AsyncIterator[AstraDBCache]:
     cache = AstraDBCache(
         collection_name="lc_integration_test_cache_async",
@@ -139,7 +139,7 @@ async def async_astradb_cache(
 
 @pytest.fixture(scope="module")
 def astradb_semantic_cache(
-    astra_db_credentials: Dict[str, Optional[str]]
+    astra_db_credentials: AstraDBCredentials
 ) -> Iterator[AstraDBSemanticCache]:
     fake_embe = FakeEmbeddings()
     sem_cache = AstraDBSemanticCache(
@@ -156,7 +156,7 @@ def astradb_semantic_cache(
 
 @pytest.fixture(scope="function")
 async def async_astradb_semantic_cache(
-    astra_db_credentials: Dict[str, Optional[str]]
+    astra_db_credentials: AstraDBCredentials
 ) -> AsyncIterator[AstraDBSemanticCache]:
     fake_embe = FakeEmbeddings()
     sem_cache = AstraDBSemanticCache(
@@ -242,7 +242,7 @@ class TestAstraDBCaches:
     )
     def test_cache_coreclients_init_sync(
         self,
-        astra_db_credentials: Dict[str, Optional[str]],
+        astra_db_credentials: AstraDBCredentials,
         core_astra_db: AstraDB,
     ) -> None:
         """A deprecation warning from passing a (core) AstraDB, but it works."""
@@ -273,7 +273,7 @@ class TestAstraDBCaches:
     )
     async def test_cache_coreclients_init_async(
         self,
-        astra_db_credentials: Dict[str, Optional[str]],
+        astra_db_credentials: AstraDBCredentials,
         core_astra_db: AstraDB,
     ) -> None:
         """A deprecation warning from passing a (core) AstraDB, but it works."""
@@ -308,7 +308,7 @@ class TestAstraDBCaches:
     )
     def test_semcache_coreclients_init_sync(
         self,
-        astra_db_credentials: Dict[str, Optional[str]],
+        astra_db_credentials: AstraDBCredentials,
         core_astra_db: AstraDB,
     ) -> None:
         """A deprecation warning from passing a (core) AstraDB, but it works."""
@@ -342,7 +342,7 @@ class TestAstraDBCaches:
     )
     async def test_semcache_coreclients_init_async(
         self,
-        astra_db_credentials: Dict[str, Optional[str]],
+        astra_db_credentials: AstraDBCredentials,
         core_astra_db: AstraDB,
     ) -> None:
         """A deprecation warning from passing a (core) AstraDB, but it works."""

--- a/libs/astradb/tests/integration_tests/test_caches.py
+++ b/libs/astradb/tests/integration_tests/test_caches.py
@@ -174,13 +174,13 @@ async def async_astradb_semantic_cache(
 
 @pytest.mark.skipif(not _has_env_vars(), reason="Missing Astra DB env. vars")
 class TestAstraDBCaches:
-    def test_astradb_cache(self, astradb_cache: AstraDBCache) -> None:
+    def test_astradb_cache_sync(self, astradb_cache: AstraDBCache) -> None:
         self.do_cache_test(FakeLLM(), astradb_cache, "foo")
 
     async def test_astradb_cache_async(self, async_astradb_cache: AstraDBCache) -> None:
         await self.ado_cache_test(FakeLLM(), async_astradb_cache, "foo")
 
-    def test_astradb_semantic_cache(
+    def test_astradb_semantic_cache_sync(
         self, astradb_semantic_cache: AstraDBSemanticCache
     ) -> None:
         llm = FakeLLM()
@@ -256,7 +256,7 @@ class TestAstraDBCaches:
                 namespace=astra_db_credentials["namespace"],
             )
             cache_init_ok.update("pr", "llms", test_gens)
-            # create an equivalent store with core AstraDB in init
+            # create an equivalent cache with core AstraDB in init
             with pytest.warns(DeprecationWarning) as rec_warnings:
                 cache_init_core = AstraDBCache(
                     collection_name=collection_name,
@@ -288,7 +288,7 @@ class TestAstraDBCaches:
                 setup_mode=SetupMode.ASYNC,
             )
             await cache_init_ok.aupdate("pr", "llms", test_gens)
-            # create an equivalent store with core AstraDB in init
+            # create an equivalent cache with core AstraDB in init
             with pytest.warns(DeprecationWarning) as rec_warnings:
                 cache_init_core = AstraDBCache(
                     collection_name=collection_name,
@@ -301,10 +301,6 @@ class TestAstraDBCaches:
             await cache_init_ok.astra_env.async_database.drop_collection(
                 collection_name
             )
-
-
-
-
 
     @pytest.mark.skipif(
         os.environ.get("ASTRA_DB_ENVIRONMENT", "prod").upper() != "PROD",
@@ -328,7 +324,7 @@ class TestAstraDBCaches:
                 embedding=fake_embe,
             )
             cache_init_ok.update("pr", "llms", test_gens)
-            # create an equivalent store with core AstraDB in init
+            # create an equivalent cache with core AstraDB in init
             with pytest.warns(DeprecationWarning) as rec_warnings:
                 cache_init_core = AstraDBSemanticCache(
                     collection_name=collection_name,
@@ -363,7 +359,7 @@ class TestAstraDBCaches:
                 embedding=fake_embe,
             )
             await cache_init_ok.aupdate("pr", "llms", test_gens)
-            # create an equivalent store with core AstraDB in init
+            # create an equivalent cache with core AstraDB in init
             with pytest.warns(DeprecationWarning) as rec_warnings:
                 cache_init_core = AstraDBSemanticCache(
                     collection_name=collection_name,

--- a/libs/astradb/tests/integration_tests/test_caches.py
+++ b/libs/astradb/tests/integration_tests/test_caches.py
@@ -15,6 +15,7 @@ import os
 from typing import Any, AsyncIterator, Dict, Iterator, List, Mapping, Optional, cast
 
 import pytest
+from astrapy.db import AstraDB
 from langchain_core.caches import BaseCache
 from langchain_core.callbacks import CallbackManagerForLLMRun
 from langchain_core.embeddings import Embeddings
@@ -25,6 +26,8 @@ from langchain_core.pydantic_v1 import validator
 
 from langchain_astradb import AstraDBCache, AstraDBSemanticCache
 from langchain_astradb.utils.astradb import SetupMode
+
+from .conftest import _has_env_vars
 
 
 class FakeEmbeddings(Embeddings):
@@ -103,34 +106,31 @@ class FakeLLM(LLM):
         return response
 
 
-def _has_env_vars() -> bool:
-    return all(
-        [
-            "ASTRA_DB_APPLICATION_TOKEN" in os.environ,
-            "ASTRA_DB_API_ENDPOINT" in os.environ,
-        ]
-    )
-
-
 @pytest.fixture(scope="module")
-def astradb_cache() -> Iterator[AstraDBCache]:
+def astradb_cache(
+    astra_db_credentials: Dict[str, Optional[str]]
+) -> Iterator[AstraDBCache]:
     cache = AstraDBCache(
         collection_name="lc_integration_test_cache",
-        token=os.environ["ASTRA_DB_APPLICATION_TOKEN"],
-        api_endpoint=os.environ["ASTRA_DB_API_ENDPOINT"],
-        namespace=os.environ.get("ASTRA_DB_KEYSPACE"),
+        token=astra_db_credentials["token"],
+        api_endpoint=astra_db_credentials["api_endpoint"],
+        namespace=astra_db_credentials["namespace"],
+        environment=astra_db_credentials["environment"],
     )
     yield cache
     cache.collection.drop()
 
 
-@pytest.fixture
-async def async_astradb_cache() -> AsyncIterator[AstraDBCache]:
+@pytest.fixture(scope="function")
+async def async_astradb_cache(
+    astra_db_credentials: Dict[str, Optional[str]]
+) -> AsyncIterator[AstraDBCache]:
     cache = AstraDBCache(
         collection_name="lc_integration_test_cache_async",
-        token=os.environ["ASTRA_DB_APPLICATION_TOKEN"],
-        api_endpoint=os.environ["ASTRA_DB_API_ENDPOINT"],
-        namespace=os.environ.get("ASTRA_DB_KEYSPACE"),
+        token=astra_db_credentials["token"],
+        api_endpoint=astra_db_credentials["api_endpoint"],
+        namespace=astra_db_credentials["namespace"],
+        environment=astra_db_credentials["environment"],
         setup_mode=SetupMode.ASYNC,
     )
     yield cache
@@ -138,27 +138,33 @@ async def async_astradb_cache() -> AsyncIterator[AstraDBCache]:
 
 
 @pytest.fixture(scope="module")
-def astradb_semantic_cache() -> Iterator[AstraDBSemanticCache]:
+def astradb_semantic_cache(
+    astra_db_credentials: Dict[str, Optional[str]]
+) -> Iterator[AstraDBSemanticCache]:
     fake_embe = FakeEmbeddings()
     sem_cache = AstraDBSemanticCache(
         collection_name="lc_integration_test_sem_cache",
-        token=os.environ["ASTRA_DB_APPLICATION_TOKEN"],
-        api_endpoint=os.environ["ASTRA_DB_API_ENDPOINT"],
-        namespace=os.environ.get("ASTRA_DB_KEYSPACE"),
+        token=astra_db_credentials["token"],
+        api_endpoint=astra_db_credentials["api_endpoint"],
+        namespace=astra_db_credentials["namespace"],
+        environment=astra_db_credentials["environment"],
         embedding=fake_embe,
     )
     yield sem_cache
     sem_cache.collection.drop()
 
 
-@pytest.fixture
-async def async_astradb_semantic_cache() -> AsyncIterator[AstraDBSemanticCache]:
+@pytest.fixture(scope="function")
+async def async_astradb_semantic_cache(
+    astra_db_credentials: Dict[str, Optional[str]]
+) -> AsyncIterator[AstraDBSemanticCache]:
     fake_embe = FakeEmbeddings()
     sem_cache = AstraDBSemanticCache(
         collection_name="lc_integration_test_sem_cache_async",
-        token=os.environ["ASTRA_DB_APPLICATION_TOKEN"],
-        api_endpoint=os.environ["ASTRA_DB_API_ENDPOINT"],
-        namespace=os.environ.get("ASTRA_DB_KEYSPACE"),
+        token=astra_db_credentials["token"],
+        api_endpoint=astra_db_credentials["api_endpoint"],
+        namespace=astra_db_credentials["namespace"],
+        environment=astra_db_credentials["environment"],
         embedding=fake_embe,
         setup_mode=SetupMode.ASYNC,
     )
@@ -229,3 +235,145 @@ class TestAstraDBCaches:
         assert output == expected_output
         # clear the cache
         await cache.aclear()
+
+    @pytest.mark.skipif(
+        os.environ.get("ASTRA_DB_ENVIRONMENT", "prod").upper() != "PROD",
+        reason="Can run on Astra DB prod only",
+    )
+    def test_cache_coreclients_init_sync(
+        self,
+        astra_db_credentials: Dict[str, Optional[str]],
+        core_astra_db: AstraDB,
+    ) -> None:
+        """A deprecation warning from passing a (core) AstraDB, but it works."""
+        collection_name = "lc_test_cache_coreclsync"
+        test_gens = [Generation(text="ret_val0123")]
+        try:
+            cache_init_ok = AstraDBCache(
+                collection_name=collection_name,
+                token=astra_db_credentials["token"],
+                api_endpoint=astra_db_credentials["api_endpoint"],
+                namespace=astra_db_credentials["namespace"],
+            )
+            cache_init_ok.update("pr", "llms", test_gens)
+            # create an equivalent store with core AstraDB in init
+            with pytest.warns(DeprecationWarning) as rec_warnings:
+                cache_init_core = AstraDBCache(
+                    collection_name=collection_name,
+                    astra_db_client=core_astra_db,
+                )
+            assert len(rec_warnings) == 1
+            assert cache_init_core.lookup("pr", "llms") == test_gens
+        finally:
+            cache_init_ok.astra_env.database.drop_collection(collection_name)
+
+    @pytest.mark.skipif(
+        os.environ.get("ASTRA_DB_ENVIRONMENT", "prod").upper() != "PROD",
+        reason="Can run on Astra DB prod only",
+    )
+    async def test_cache_coreclients_init_async(
+        self,
+        astra_db_credentials: Dict[str, Optional[str]],
+        core_astra_db: AstraDB,
+    ) -> None:
+        """A deprecation warning from passing a (core) AstraDB, but it works."""
+        collection_name = "lc_test_cache_coreclasync"
+        test_gens = [Generation(text="ret_val4567")]
+        try:
+            cache_init_ok = AstraDBCache(
+                collection_name=collection_name,
+                token=astra_db_credentials["token"],
+                api_endpoint=astra_db_credentials["api_endpoint"],
+                namespace=astra_db_credentials["namespace"],
+                setup_mode=SetupMode.ASYNC,
+            )
+            await cache_init_ok.aupdate("pr", "llms", test_gens)
+            # create an equivalent store with core AstraDB in init
+            with pytest.warns(DeprecationWarning) as rec_warnings:
+                cache_init_core = AstraDBCache(
+                    collection_name=collection_name,
+                    astra_db_client=core_astra_db,
+                    setup_mode=SetupMode.ASYNC,
+                )
+            assert len(rec_warnings) == 1
+            assert await cache_init_core.alookup("pr", "llms") == test_gens
+        finally:
+            await cache_init_ok.astra_env.async_database.drop_collection(
+                collection_name
+            )
+
+
+
+
+
+    @pytest.mark.skipif(
+        os.environ.get("ASTRA_DB_ENVIRONMENT", "prod").upper() != "PROD",
+        reason="Can run on Astra DB prod only",
+    )
+    def test_semcache_coreclients_init_sync(
+        self,
+        astra_db_credentials: Dict[str, Optional[str]],
+        core_astra_db: AstraDB,
+    ) -> None:
+        """A deprecation warning from passing a (core) AstraDB, but it works."""
+        fake_embe = FakeEmbeddings()
+        collection_name = "lc_test_cache_coreclsync"
+        test_gens = [Generation(text="ret_val0123")]
+        try:
+            cache_init_ok = AstraDBSemanticCache(
+                collection_name=collection_name,
+                token=astra_db_credentials["token"],
+                api_endpoint=astra_db_credentials["api_endpoint"],
+                namespace=astra_db_credentials["namespace"],
+                embedding=fake_embe,
+            )
+            cache_init_ok.update("pr", "llms", test_gens)
+            # create an equivalent store with core AstraDB in init
+            with pytest.warns(DeprecationWarning) as rec_warnings:
+                cache_init_core = AstraDBSemanticCache(
+                    collection_name=collection_name,
+                    astra_db_client=core_astra_db,
+                    embedding=fake_embe,
+                )
+            assert len(rec_warnings) == 1
+            assert cache_init_core.lookup("pr", "llms") == test_gens
+        finally:
+            cache_init_ok.astra_env.database.drop_collection(collection_name)
+
+    @pytest.mark.skipif(
+        os.environ.get("ASTRA_DB_ENVIRONMENT", "prod").upper() != "PROD",
+        reason="Can run on Astra DB prod only",
+    )
+    async def test_semcache_coreclients_init_async(
+        self,
+        astra_db_credentials: Dict[str, Optional[str]],
+        core_astra_db: AstraDB,
+    ) -> None:
+        """A deprecation warning from passing a (core) AstraDB, but it works."""
+        fake_embe = FakeEmbeddings()
+        collection_name = "lc_test_cache_coreclasync"
+        test_gens = [Generation(text="ret_val4567")]
+        try:
+            cache_init_ok = AstraDBSemanticCache(
+                collection_name=collection_name,
+                token=astra_db_credentials["token"],
+                api_endpoint=astra_db_credentials["api_endpoint"],
+                namespace=astra_db_credentials["namespace"],
+                setup_mode=SetupMode.ASYNC,
+                embedding=fake_embe,
+            )
+            await cache_init_ok.aupdate("pr", "llms", test_gens)
+            # create an equivalent store with core AstraDB in init
+            with pytest.warns(DeprecationWarning) as rec_warnings:
+                cache_init_core = AstraDBSemanticCache(
+                    collection_name=collection_name,
+                    astra_db_client=core_astra_db,
+                    setup_mode=SetupMode.ASYNC,
+                    embedding=fake_embe,
+                )
+            assert len(rec_warnings) == 1
+            assert await cache_init_core.alookup("pr", "llms") == test_gens
+        finally:
+            await cache_init_ok.astra_env.async_database.drop_collection(
+                collection_name
+            )

--- a/libs/astradb/tests/integration_tests/test_caches.py
+++ b/libs/astradb/tests/integration_tests/test_caches.py
@@ -27,7 +27,7 @@ from langchain_core.pydantic_v1 import validator
 from langchain_astradb import AstraDBCache, AstraDBSemanticCache
 from langchain_astradb.utils.astradb import SetupMode
 
-from .conftest import _has_env_vars, AstraDBCredentials
+from .conftest import AstraDBCredentials, _has_env_vars
 
 
 class FakeEmbeddings(Embeddings):

--- a/libs/astradb/tests/integration_tests/test_caches.py
+++ b/libs/astradb/tests/integration_tests/test_caches.py
@@ -121,7 +121,7 @@ def astradb_cache() -> Iterator[AstraDBCache]:
         namespace=os.environ.get("ASTRA_DB_KEYSPACE"),
     )
     yield cache
-    cache.collection.astra_db.delete_collection("lc_integration_test_cache")
+    cache.collection.drop()
 
 
 @pytest.fixture
@@ -134,9 +134,7 @@ async def async_astradb_cache() -> AsyncIterator[AstraDBCache]:
         setup_mode=SetupMode.ASYNC,
     )
     yield cache
-    await cache.async_collection.astra_db.delete_collection(
-        "lc_integration_test_cache_async"
-    )
+    await cache.async_collection.drop()
 
 
 @pytest.fixture(scope="module")
@@ -150,7 +148,7 @@ def astradb_semantic_cache() -> Iterator[AstraDBSemanticCache]:
         embedding=fake_embe,
     )
     yield sem_cache
-    sem_cache.collection.astra_db.delete_collection("lc_integration_test_sem_cache")
+    sem_cache.collection.drop()
 
 
 @pytest.fixture
@@ -165,9 +163,7 @@ async def async_astradb_semantic_cache() -> AsyncIterator[AstraDBSemanticCache]:
         setup_mode=SetupMode.ASYNC,
     )
     yield sem_cache
-    sem_cache.collection.astra_db.delete_collection(
-        "lc_integration_test_sem_cache_async"
-    )
+    sem_cache.collection.drop()
 
 
 @pytest.mark.skipif(not _has_env_vars(), reason="Missing Astra DB env. vars")

--- a/libs/astradb/tests/integration_tests/test_chat_message_histories.py
+++ b/libs/astradb/tests/integration_tests/test_chat_message_histories.py
@@ -1,7 +1,8 @@
 import os
-from typing import AsyncIterable, Iterable
+from typing import AsyncIterable, Dict, Iterable, Optional
 
 import pytest
+from astrapy.db import AstraDB
 from langchain.memory import ConversationBufferMemory
 from langchain_core.messages import AIMessage, HumanMessage
 
@@ -10,39 +11,37 @@ from langchain_astradb.chat_message_histories import (
 )
 from langchain_astradb.utils.astradb import SetupMode
 
-
-def _has_env_vars() -> bool:
-    return all(
-        [
-            "ASTRA_DB_APPLICATION_TOKEN" in os.environ,
-            "ASTRA_DB_API_ENDPOINT" in os.environ,
-        ]
-    )
+from .conftest import _has_env_vars
 
 
 @pytest.fixture(scope="function")
-def history1() -> Iterable[AstraDBChatMessageHistory]:
+def history1(
+    astra_db_credentials: Dict[str, Optional[str]]
+) -> Iterable[AstraDBChatMessageHistory]:
     history1 = AstraDBChatMessageHistory(
         session_id="session-test-1",
         collection_name="langchain_cmh_test",
-        token=os.environ["ASTRA_DB_APPLICATION_TOKEN"],
-        api_endpoint=os.environ["ASTRA_DB_API_ENDPOINT"],
-        namespace=os.environ.get("ASTRA_DB_KEYSPACE"),
+        token=astra_db_credentials["token"],
+        api_endpoint=astra_db_credentials["api_endpoint"],
+        namespace=astra_db_credentials["namespace"],
+        environment=astra_db_credentials["environment"],
     )
     yield history1
-    history1.collection.astra_db.delete_collection("langchain_cmh_test")
+    history1.collection.drop()
 
 
 @pytest.fixture(scope="function")
 def history2(
     history1: AstraDBChatMessageHistory,
+    astra_db_credentials: Dict[str, Optional[str]],
 ) -> Iterable[AstraDBChatMessageHistory]:
     history2 = AstraDBChatMessageHistory(
         session_id="session-test-2",
         collection_name=history1.collection_name,
-        token=os.environ["ASTRA_DB_APPLICATION_TOKEN"],
-        api_endpoint=os.environ["ASTRA_DB_API_ENDPOINT"],
-        namespace=os.environ.get("ASTRA_DB_KEYSPACE"),
+        token=astra_db_credentials["token"],
+        api_endpoint=astra_db_credentials["api_endpoint"],
+        namespace=astra_db_credentials["namespace"],
+        environment=astra_db_credentials["environment"],
         # this, with the dependency from history1, ensures
         # no two createCollection calls at once are issued:
         setup_mode=SetupMode.OFF,
@@ -52,29 +51,34 @@ def history2(
 
 
 @pytest.fixture
-async def async_history1() -> AsyncIterable[AstraDBChatMessageHistory]:
+async def async_history1(
+    astra_db_credentials: Dict[str, Optional[str]]
+) -> AsyncIterable[AstraDBChatMessageHistory]:
     history1 = AstraDBChatMessageHistory(
         session_id="async-session-test-1",
         collection_name="langchain_cmh_test",
-        token=os.environ["ASTRA_DB_APPLICATION_TOKEN"],
-        api_endpoint=os.environ["ASTRA_DB_API_ENDPOINT"],
-        namespace=os.environ.get("ASTRA_DB_KEYSPACE"),
+        token=astra_db_credentials["token"],
+        api_endpoint=astra_db_credentials["api_endpoint"],
+        namespace=astra_db_credentials["namespace"],
+        environment=astra_db_credentials["environment"],
         setup_mode=SetupMode.ASYNC,
     )
     yield history1
-    await history1.async_collection.astra_db.delete_collection("langchain_cmh_test")
+    await history1.async_collection.drop()
 
 
 @pytest.fixture(scope="function")
 async def async_history2(
     history1: AstraDBChatMessageHistory,
+    astra_db_credentials: Dict[str, Optional[str]],
 ) -> AsyncIterable[AstraDBChatMessageHistory]:
     history2 = AstraDBChatMessageHistory(
         session_id="async-session-test-2",
         collection_name=history1.collection_name,
-        token=os.environ["ASTRA_DB_APPLICATION_TOKEN"],
-        api_endpoint=os.environ["ASTRA_DB_API_ENDPOINT"],
-        namespace=os.environ.get("ASTRA_DB_KEYSPACE"),
+        token=astra_db_credentials["token"],
+        api_endpoint=astra_db_credentials["api_endpoint"],
+        namespace=astra_db_credentials["namespace"],
+        environment=astra_db_credentials["environment"],
         # this, with the dependency from history1, ensures
         # no two createCollection calls at once are issued:
         setup_mode=SetupMode.OFF,
@@ -84,124 +88,182 @@ async def async_history2(
 
 
 @pytest.mark.skipif(not _has_env_vars(), reason="Missing Astra DB env. vars")
-def test_memory_with_message_store(history1: AstraDBChatMessageHistory) -> None:
-    """Test the memory with a message store."""
-    memory = ConversationBufferMemory(
-        memory_key="baz",
-        chat_memory=history1,
-        return_messages=True,
-    )
+class TestAstraDBChatMessageHistories:
+    def test_memory_with_message_store(
+        self, history1: AstraDBChatMessageHistory
+    ) -> None:
+        """Test the memory with a message store."""
+        memory = ConversationBufferMemory(
+            memory_key="baz",
+            chat_memory=history1,
+            return_messages=True,
+        )
 
-    assert memory.chat_memory.messages == []
+        assert memory.chat_memory.messages == []
 
-    # add some messages
-    memory.chat_memory.add_messages(
-        [
+        # add some messages
+        memory.chat_memory.add_messages(
+            [
+                AIMessage(content="This is me, the AI"),
+                HumanMessage(content="This is me, the human"),
+            ]
+        )
+
+        messages = memory.chat_memory.messages
+        expected = [
             AIMessage(content="This is me, the AI"),
             HumanMessage(content="This is me, the human"),
         ]
-    )
+        assert messages == expected
 
-    messages = memory.chat_memory.messages
-    expected = [
-        AIMessage(content="This is me, the AI"),
-        HumanMessage(content="This is me, the human"),
-    ]
-    assert messages == expected
+        # clear the store
+        memory.chat_memory.clear()
 
-    # clear the store
-    memory.chat_memory.clear()
+        assert memory.chat_memory.messages == []
 
-    assert memory.chat_memory.messages == []
+    async def test_memory_with_message_store_async(
+        self,
+        async_history1: AstraDBChatMessageHistory,
+    ) -> None:
+        """Test the memory with a message store."""
+        memory = ConversationBufferMemory(
+            memory_key="baz",
+            chat_memory=async_history1,
+            return_messages=True,
+        )
 
+        assert await memory.chat_memory.aget_messages() == []
 
-@pytest.mark.skipif(not _has_env_vars(), reason="Missing Astra DB env. vars")
-async def test_memory_with_message_store_async(
-    async_history1: AstraDBChatMessageHistory,
-) -> None:
-    """Test the memory with a message store."""
-    memory = ConversationBufferMemory(
-        memory_key="baz",
-        chat_memory=async_history1,
-        return_messages=True,
-    )
+        # add some messages
+        await memory.chat_memory.aadd_messages(
+            [
+                AIMessage(content="This is me, the AI"),
+                HumanMessage(content="This is me, the human"),
+            ]
+        )
 
-    assert await memory.chat_memory.aget_messages() == []
-
-    # add some messages
-    await memory.chat_memory.aadd_messages(
-        [
+        messages = await memory.chat_memory.aget_messages()
+        expected = [
             AIMessage(content="This is me, the AI"),
             HumanMessage(content="This is me, the human"),
         ]
+        assert messages == expected
+
+        # clear the store
+        await memory.chat_memory.aclear()
+
+        assert await memory.chat_memory.aget_messages() == []
+
+    def test_memory_separate_session_ids(
+        self, history1: AstraDBChatMessageHistory, history2: AstraDBChatMessageHistory
+    ) -> None:
+        """Test that separate session IDs do not share entries."""
+        memory1 = ConversationBufferMemory(
+            memory_key="mk1",
+            chat_memory=history1,
+            return_messages=True,
+        )
+        memory2 = ConversationBufferMemory(
+            memory_key="mk2",
+            chat_memory=history2,
+            return_messages=True,
+        )
+
+        memory1.chat_memory.add_messages([AIMessage(content="Just saying.")])
+        assert memory2.chat_memory.messages == []
+        memory2.chat_memory.clear()
+        assert memory1.chat_memory.messages != []
+        memory1.chat_memory.clear()
+        assert memory1.chat_memory.messages == []
+
+    async def test_memory_separate_session_ids_async(
+        self,
+        async_history1: AstraDBChatMessageHistory,
+        async_history2: AstraDBChatMessageHistory,
+    ) -> None:
+        """Test that separate session IDs do not share entries."""
+        memory1 = ConversationBufferMemory(
+            memory_key="mk1",
+            chat_memory=async_history1,
+            return_messages=True,
+        )
+        memory2 = ConversationBufferMemory(
+            memory_key="mk2",
+            chat_memory=async_history2,
+            return_messages=True,
+        )
+
+        await memory1.chat_memory.aadd_messages([AIMessage(content="Just saying.")])
+        assert await memory2.chat_memory.aget_messages() == []
+        await memory2.chat_memory.aclear()
+        assert await memory1.chat_memory.aget_messages() != []
+        await memory1.chat_memory.aclear()
+        assert await memory1.chat_memory.aget_messages() == []
+
+    @pytest.mark.skipif(
+        os.environ.get("ASTRA_DB_ENVIRONMENT", "prod").upper() != "PROD",
+        reason="Can run on Astra DB prod only",
     )
+    def test_chatms_coreclients_init_sync(
+        self,
+        astra_db_credentials: Dict[str, Optional[str]],
+        core_astra_db: AstraDB,
+    ) -> None:
+        """A deprecation warning from passing a (core) AstraDB, but it works."""
+        collection_name = "lc_test_cmh_coreclsync"
+        test_messages=[AIMessage(content="Meow.")]
+        try:
+            chatmh_init_ok = AstraDBChatMessageHistory(
+                session_id="gattini",
+                collection_name=collection_name,
+                token=astra_db_credentials["token"],
+                api_endpoint=astra_db_credentials["api_endpoint"],
+                namespace=astra_db_credentials["namespace"],
+            )
+            chatmh_init_ok.add_messages(test_messages)
+            # create an equivalent cache with core AstraDB in init
+            with pytest.warns(DeprecationWarning) as rec_warnings:
+                chatmh_init_core = AstraDBChatMessageHistory(
+                    collection_name=collection_name,
+                    session_id="gattini",
+                    astra_db_client=core_astra_db,
+                )
+            assert len(rec_warnings) == 1
+            assert chatmh_init_core.messages == test_messages
+        finally:
+            chatmh_init_ok.astra_env.collection.drop()
 
-    messages = await memory.chat_memory.aget_messages()
-    expected = [
-        AIMessage(content="This is me, the AI"),
-        HumanMessage(content="This is me, the human"),
-    ]
-    assert messages == expected
-
-    # clear the store
-    await memory.chat_memory.aclear()
-
-    assert await memory.chat_memory.aget_messages() == []
-
-
-@pytest.mark.skipif(not _has_env_vars(), reason="Missing Astra DB env. vars")
-def test_memory_separate_session_ids(
-    history1: AstraDBChatMessageHistory, history2: AstraDBChatMessageHistory
-) -> None:
-    """Test that separate session IDs do not share entries."""
-    memory1 = ConversationBufferMemory(
-        memory_key="mk1",
-        chat_memory=history1,
-        return_messages=True,
+    @pytest.mark.skipif(
+        os.environ.get("ASTRA_DB_ENVIRONMENT", "prod").upper() != "PROD",
+        reason="Can run on Astra DB prod only",
     )
-    memory2 = ConversationBufferMemory(
-        memory_key="mk2",
-        chat_memory=history2,
-        return_messages=True,
-    )
-
-    memory1.chat_memory.add_messages([AIMessage(content="Just saying.")])
-
-    assert memory2.chat_memory.messages == []
-
-    memory2.chat_memory.clear()
-
-    assert memory1.chat_memory.messages != []
-
-    memory1.chat_memory.clear()
-
-    assert memory1.chat_memory.messages == []
-
-
-@pytest.mark.skipif(not _has_env_vars(), reason="Missing Astra DB env. vars")
-async def test_memory_separate_session_ids_async(
-    async_history1: AstraDBChatMessageHistory, async_history2: AstraDBChatMessageHistory
-) -> None:
-    """Test that separate session IDs do not share entries."""
-    memory1 = ConversationBufferMemory(
-        memory_key="mk1",
-        chat_memory=async_history1,
-        return_messages=True,
-    )
-    memory2 = ConversationBufferMemory(
-        memory_key="mk2",
-        chat_memory=async_history2,
-        return_messages=True,
-    )
-
-    await memory1.chat_memory.aadd_messages([AIMessage(content="Just saying.")])
-
-    assert await memory2.chat_memory.aget_messages() == []
-
-    await memory2.chat_memory.aclear()
-
-    assert await memory1.chat_memory.aget_messages() != []
-
-    await memory1.chat_memory.aclear()
-
-    assert await memory1.chat_memory.aget_messages() == []
+    async def test_chatms_coreclients_init_async(
+        self,
+        astra_db_credentials: Dict[str, Optional[str]],
+        core_astra_db: AstraDB,
+    ) -> None:
+        """A deprecation warning from passing a (core) AstraDB, but it works."""
+        collection_name = "lc_test_cmh_coreclasync"
+        test_messages=[AIMessage(content="Ameow.")]
+        try:
+            chatmh_init_ok = AstraDBChatMessageHistory(
+                session_id="gattini",
+                collection_name=collection_name,
+                token=astra_db_credentials["token"],
+                api_endpoint=astra_db_credentials["api_endpoint"],
+                namespace=astra_db_credentials["namespace"],
+                setup_mode=SetupMode.ASYNC,
+            )
+            await chatmh_init_ok.aadd_messages(test_messages)
+            # create an equivalent cache with core AstraDB in init
+            with pytest.warns(DeprecationWarning) as rec_warnings:
+                chatmh_init_core = AstraDBChatMessageHistory(
+                    collection_name=collection_name,
+                    session_id="gattini",
+                    astra_db_client=core_astra_db,
+                    setup_mode=SetupMode.ASYNC,
+                )
+            assert len(rec_warnings) == 1
+            assert await chatmh_init_core.aget_messages() == test_messages
+        finally:
+            await chatmh_init_ok.astra_env.async_collection.drop()

--- a/libs/astradb/tests/integration_tests/test_chat_message_histories.py
+++ b/libs/astradb/tests/integration_tests/test_chat_message_histories.py
@@ -11,12 +11,12 @@ from langchain_astradb.chat_message_histories import (
 )
 from langchain_astradb.utils.astradb import SetupMode
 
-from .conftest import _has_env_vars
+from .conftest import _has_env_vars, AstraDBCredentials
 
 
 @pytest.fixture(scope="function")
 def history1(
-    astra_db_credentials: Dict[str, Optional[str]]
+    astra_db_credentials: AstraDBCredentials
 ) -> Iterable[AstraDBChatMessageHistory]:
     history1 = AstraDBChatMessageHistory(
         session_id="session-test-1",
@@ -33,7 +33,7 @@ def history1(
 @pytest.fixture(scope="function")
 def history2(
     history1: AstraDBChatMessageHistory,
-    astra_db_credentials: Dict[str, Optional[str]],
+    astra_db_credentials: AstraDBCredentials,
 ) -> Iterable[AstraDBChatMessageHistory]:
     history2 = AstraDBChatMessageHistory(
         session_id="session-test-2",
@@ -52,7 +52,7 @@ def history2(
 
 @pytest.fixture
 async def async_history1(
-    astra_db_credentials: Dict[str, Optional[str]]
+    astra_db_credentials: AstraDBCredentials
 ) -> AsyncIterable[AstraDBChatMessageHistory]:
     history1 = AstraDBChatMessageHistory(
         session_id="async-session-test-1",
@@ -70,7 +70,7 @@ async def async_history1(
 @pytest.fixture(scope="function")
 async def async_history2(
     history1: AstraDBChatMessageHistory,
-    astra_db_credentials: Dict[str, Optional[str]],
+    astra_db_credentials: AstraDBCredentials,
 ) -> AsyncIterable[AstraDBChatMessageHistory]:
     history2 = AstraDBChatMessageHistory(
         session_id="async-session-test-2",
@@ -206,7 +206,7 @@ class TestAstraDBChatMessageHistories:
     )
     def test_chatms_coreclients_init_sync(
         self,
-        astra_db_credentials: Dict[str, Optional[str]],
+        astra_db_credentials: AstraDBCredentials,
         core_astra_db: AstraDB,
     ) -> None:
         """A deprecation warning from passing a (core) AstraDB, but it works."""
@@ -239,7 +239,7 @@ class TestAstraDBChatMessageHistories:
     )
     async def test_chatms_coreclients_init_async(
         self,
-        astra_db_credentials: Dict[str, Optional[str]],
+        astra_db_credentials: AstraDBCredentials,
         core_astra_db: AstraDB,
     ) -> None:
         """A deprecation warning from passing a (core) AstraDB, but it works."""

--- a/libs/astradb/tests/integration_tests/test_chat_message_histories.py
+++ b/libs/astradb/tests/integration_tests/test_chat_message_histories.py
@@ -1,5 +1,5 @@
 import os
-from typing import AsyncIterable, Dict, Iterable, Optional
+from typing import AsyncIterable, Iterable
 
 import pytest
 from astrapy.db import AstraDB
@@ -11,7 +11,7 @@ from langchain_astradb.chat_message_histories import (
 )
 from langchain_astradb.utils.astradb import SetupMode
 
-from .conftest import _has_env_vars, AstraDBCredentials
+from .conftest import AstraDBCredentials, _has_env_vars
 
 
 @pytest.fixture(scope="function")

--- a/libs/astradb/tests/integration_tests/test_chat_message_histories.py
+++ b/libs/astradb/tests/integration_tests/test_chat_message_histories.py
@@ -16,7 +16,7 @@ from .conftest import AstraDBCredentials, _has_env_vars
 
 @pytest.fixture(scope="function")
 def history1(
-    astra_db_credentials: AstraDBCredentials
+    astra_db_credentials: AstraDBCredentials,
 ) -> Iterable[AstraDBChatMessageHistory]:
     history1 = AstraDBChatMessageHistory(
         session_id="session-test-1",
@@ -52,7 +52,7 @@ def history2(
 
 @pytest.fixture
 async def async_history1(
-    astra_db_credentials: AstraDBCredentials
+    astra_db_credentials: AstraDBCredentials,
 ) -> AsyncIterable[AstraDBChatMessageHistory]:
     history1 = AstraDBChatMessageHistory(
         session_id="async-session-test-1",
@@ -211,7 +211,7 @@ class TestAstraDBChatMessageHistories:
     ) -> None:
         """A deprecation warning from passing a (core) AstraDB, but it works."""
         collection_name = "lc_test_cmh_coreclsync"
-        test_messages=[AIMessage(content="Meow.")]
+        test_messages = [AIMessage(content="Meow.")]
         try:
             chatmh_init_ok = AstraDBChatMessageHistory(
                 session_id="gattini",
@@ -244,7 +244,7 @@ class TestAstraDBChatMessageHistories:
     ) -> None:
         """A deprecation warning from passing a (core) AstraDB, but it works."""
         collection_name = "lc_test_cmh_coreclasync"
-        test_messages=[AIMessage(content="Ameow.")]
+        test_messages = [AIMessage(content="Ameow.")]
         try:
             chatmh_init_ok = AstraDBChatMessageHistory(
                 session_id="gattini",

--- a/libs/astradb/tests/integration_tests/test_document_loaders.py
+++ b/libs/astradb/tests/integration_tests/test_document_loaders.py
@@ -239,6 +239,7 @@ class TestAstraDB:
             token=astra_db_credentials["token"],
             api_endpoint=astra_db_credentials["api_endpoint"],
             namespace=astra_db_credentials["namespace"],
+            environment=astra_db_credentials["environment"],
             limit=1,
         )
         docs0 = loader0.load()
@@ -249,6 +250,7 @@ class TestAstraDB:
                 token=astra_db_credentials["token"],
                 api_endpoint=astra_db_credentials["api_endpoint"],
                 namespace=astra_db_credentials["namespace"],
+                environment=astra_db_credentials["environment"],
                 find_options={"limit": 1},
             )
         assert len(rec_warnings) == 1
@@ -260,6 +262,7 @@ class TestAstraDB:
                 token=astra_db_credentials["token"],
                 api_endpoint=astra_db_credentials["api_endpoint"],
                 namespace=astra_db_credentials["namespace"],
+                environment=astra_db_credentials["environment"],
                 limit=1,
                 find_options={"limit": 1},
             )
@@ -270,6 +273,7 @@ class TestAstraDB:
                 token=astra_db_credentials["token"],
                 api_endpoint=astra_db_credentials["api_endpoint"],
                 namespace=astra_db_credentials["namespace"],
+                environment=astra_db_credentials["environment"],
                 find_options={"planets": 8, "spiders": 40000},
                 limit=1,
             )

--- a/libs/astradb/tests/integration_tests/test_document_loaders.py
+++ b/libs/astradb/tests/integration_tests/test_document_loaders.py
@@ -23,7 +23,7 @@ from astrapy.db import AstraDB
 
 from langchain_astradb import AstraDBLoader
 
-from .conftest import _has_env_vars
+from .conftest import _has_env_vars, AstraDBCredentials
 
 
 @pytest.fixture
@@ -61,7 +61,7 @@ class TestAstraDB:
     def test_astradb_loader_sync(
         self,
         collection: Collection,
-        astra_db_credentials: Dict[str, Optional[str]],
+        astra_db_credentials: AstraDBCredentials,
     ) -> None:
         loader = AstraDBLoader(
             collection.name,
@@ -93,7 +93,7 @@ class TestAstraDB:
     def test_page_content_mapper_sync(
         self,
         collection: Collection,
-        astra_db_credentials: Dict[str, Optional[str]],
+        astra_db_credentials: AstraDBCredentials,
     ) -> None:
         loader = AstraDBLoader(
             collection.name,
@@ -113,7 +113,7 @@ class TestAstraDB:
     def test_metadata_mapper_sync(
         self,
         collection: Collection,
-        astra_db_credentials: Dict[str, Optional[str]],
+        astra_db_credentials: AstraDBCredentials,
     ) -> None:
         loader = AstraDBLoader(
             collection.name,
@@ -133,7 +133,7 @@ class TestAstraDB:
     async def test_astradb_loader_async(
         self,
         async_collection: AsyncCollection,
-        astra_db_credentials: Dict[str, Optional[str]],
+        astra_db_credentials: AstraDBCredentials,
     ) -> None:
         loader = AstraDBLoader(
             async_collection.name,
@@ -165,7 +165,7 @@ class TestAstraDB:
     async def test_page_content_mapper_async(
         self,
         async_collection: AsyncCollection,
-        astra_db_credentials: Dict[str, Optional[str]],
+        astra_db_credentials: AstraDBCredentials,
     ) -> None:
         loader = AstraDBLoader(
             async_collection.name,
@@ -183,7 +183,7 @@ class TestAstraDB:
     async def test_metadata_mapper_async(
         self,
         async_collection: AsyncCollection,
-        astra_db_credentials: Dict[str, Optional[str]],
+        astra_db_credentials: AstraDBCredentials,
     ) -> None:
         loader = AstraDBLoader(
             async_collection.name,
@@ -204,7 +204,7 @@ class TestAstraDB:
     )
     def test_astradb_loader_coreclients_init(
         self,
-        astra_db_credentials: Dict[str, Optional[str]],
+        astra_db_credentials: AstraDBCredentials,
         collection: Collection,
         core_astra_db: AstraDB,
     ) -> None:
@@ -229,7 +229,7 @@ class TestAstraDB:
 
     def test_astradb_loader_findoptions_deprecation(
         self,
-        astra_db_credentials: Dict[str, Optional[str]],
+        astra_db_credentials: AstraDBCredentials,
         collection: Collection,
         core_astra_db: AstraDB,
     ) -> None:

--- a/libs/astradb/tests/integration_tests/test_document_loaders.py
+++ b/libs/astradb/tests/integration_tests/test_document_loaders.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 import json
 import os
 import uuid
-from typing import AsyncIterator, Dict, Iterator, Optional
+from typing import AsyncIterator, Iterator
 
 import pytest
 from astrapy import AsyncCollection, Collection, Database
@@ -23,7 +23,7 @@ from astrapy.db import AstraDB
 
 from langchain_astradb import AstraDBLoader
 
-from .conftest import _has_env_vars, AstraDBCredentials
+from .conftest import AstraDBCredentials, _has_env_vars
 
 
 @pytest.fixture

--- a/libs/astradb/tests/integration_tests/test_document_loaders.py
+++ b/libs/astradb/tests/integration_tests/test_document_loaders.py
@@ -257,7 +257,9 @@ class TestAstraDB:
         with pytest.raises(ValueError):
             AstraDBLoader(
                 collection_name=collection.name,
-                astra_db_client=core_astra_db,
+                token=astra_db_credentials["token"],
+                api_endpoint=astra_db_credentials["api_endpoint"],
+                namespace=astra_db_credentials["namespace"],
                 limit=1,
                 find_options={"limit": 1},
             )

--- a/libs/astradb/tests/integration_tests/test_storage.py
+++ b/libs/astradb/tests/integration_tests/test_storage.py
@@ -11,43 +11,7 @@ from astrapy.db import AstraDB
 from langchain_astradb.storage import AstraDBByteStore, AstraDBStore
 from langchain_astradb.utils.astradb import SetupMode
 
-
-def _has_env_vars() -> bool:
-    return all(
-        [
-            "ASTRA_DB_APPLICATION_TOKEN" in os.environ,
-            "ASTRA_DB_API_ENDPOINT" in os.environ,
-        ]
-    )
-
-
-@pytest.fixture
-def astra_db_credentials() -> Dict[str, Optional[str]]:
-    return {
-        "token": os.environ["ASTRA_DB_APPLICATION_TOKEN"],
-        "api_endpoint": os.environ["ASTRA_DB_API_ENDPOINT"],
-        "namespace": os.environ.get("ASTRA_DB_KEYSPACE"),
-        "environment": os.environ.get("ASTRA_DB_ENVIRONMENT"),
-    }
-
-
-@pytest.fixture
-def database(astra_db_credentials: Dict[str, Optional[str]]) -> Database:
-    return Database(
-        token=astra_db_credentials["token"],
-        api_endpoint=astra_db_credentials["api_endpoint"],  # type: ignore[arg-type]
-        namespace=astra_db_credentials["namespace"],
-        environment=astra_db_credentials["environment"],
-    )
-
-
-@pytest.fixture
-def core_astra_db(astra_db_credentials: Dict[str, Optional[str]]) -> AstraDB:
-    return AstraDB(
-        token=astra_db_credentials["token"],
-        api_endpoint=astra_db_credentials["api_endpoint"],  # type: ignore[arg-type]
-        namespace=astra_db_credentials["namespace"],
-    )
+from .conftest import _has_env_vars
 
 
 def init_store(
@@ -310,8 +274,8 @@ class TestAstraDBStore:
                     collection_name=collection_name,
                     astra_db_client=core_astra_db,
                 )
-                assert len(rec_warnings) == 1
-                assert store_init_core.mget(["key"]) == ["val123"]
+            assert len(rec_warnings) == 1
+            assert store_init_core.mget(["key"]) == ["val123"]
         finally:
             store_init_ok.astra_env.database.drop_collection(collection_name)
 
@@ -342,7 +306,9 @@ class TestAstraDBStore:
                     astra_db_client=core_astra_db,
                     setup_mode=SetupMode.ASYNC,
                 )
-                assert len(rec_warnings) == 1
-                assert await store_init_core.amget(["key"]) == ["val123"]
+            assert len(rec_warnings) == 1
+            assert await store_init_core.amget(["key"]) == ["val123"]
         finally:
-            await store_init_ok.astra_env.async_database.drop_collection(collection_name)
+            await store_init_ok.astra_env.async_database.drop_collection(
+                collection_name
+            )

--- a/libs/astradb/tests/integration_tests/test_storage.py
+++ b/libs/astradb/tests/integration_tests/test_storage.py
@@ -2,9 +2,11 @@
 from __future__ import annotations
 
 import os
+from typing import Dict, Optional
 
 import pytest
-from astrapy.db import AstraDB, AsyncAstraDB
+from astrapy import Database
+from astrapy.db import AstraDB
 
 from langchain_astradb.storage import AstraDBByteStore, AstraDBStore
 from langchain_astradb.utils.astradb import SetupMode
@@ -20,41 +22,73 @@ def _has_env_vars() -> bool:
 
 
 @pytest.fixture
-def astra_db() -> AstraDB:
-    return AstraDB(
-        token=os.environ["ASTRA_DB_APPLICATION_TOKEN"],
-        api_endpoint=os.environ["ASTRA_DB_API_ENDPOINT"],
-        namespace=os.environ.get("ASTRA_DB_KEYSPACE"),
+def astra_db_credentials() -> Dict[str, Optional[str]]:
+    return {
+        "token": os.environ["ASTRA_DB_APPLICATION_TOKEN"],
+        "api_endpoint": os.environ["ASTRA_DB_API_ENDPOINT"],
+        "namespace": os.environ.get("ASTRA_DB_KEYSPACE"),
+        "environment": os.environ.get("ASTRA_DB_ENVIRONMENT"),
+    }
+
+
+@pytest.fixture
+def database(astra_db_credentials: Dict[str, Optional[str]]) -> Database:
+    return Database(
+        token=astra_db_credentials["token"],
+        api_endpoint=astra_db_credentials["api_endpoint"],  # type: ignore[arg-type]
+        namespace=astra_db_credentials["namespace"],
+        environment=astra_db_credentials["environment"],
     )
 
 
 @pytest.fixture
-def async_astra_db() -> AsyncAstraDB:
-    return AsyncAstraDB(
-        token=os.environ["ASTRA_DB_APPLICATION_TOKEN"],
-        api_endpoint=os.environ["ASTRA_DB_API_ENDPOINT"],
-        namespace=os.environ.get("ASTRA_DB_KEYSPACE"),
+def core_astra_db(astra_db_credentials: Dict[str, Optional[str]]) -> AstraDB:
+    return AstraDB(
+        token=astra_db_credentials["token"],
+        api_endpoint=astra_db_credentials["api_endpoint"],  # type: ignore[arg-type]
+        namespace=astra_db_credentials["namespace"],
     )
 
 
-def init_store(astra_db: AstraDB, collection_name: str) -> AstraDBStore:
-    store = AstraDBStore(collection_name=collection_name, astra_db_client=astra_db)
+def init_store(
+    astra_db_credentials: Dict[str, Optional[str]],
+    collection_name: str,
+) -> AstraDBStore:
+    store = AstraDBStore(
+        collection_name=collection_name,
+        token=astra_db_credentials["token"],
+        api_endpoint=astra_db_credentials["api_endpoint"],
+        namespace=astra_db_credentials["namespace"],
+        environment=astra_db_credentials["environment"],
+    )
     store.mset([("key1", [0.1, 0.2]), ("key2", "value2")])
     return store
 
 
-def init_bytestore(astra_db: AstraDB, collection_name: str) -> AstraDBByteStore:
-    store = AstraDBByteStore(collection_name=collection_name, astra_db_client=astra_db)
+def init_bytestore(
+    astra_db_credentials: Dict[str, Optional[str]],
+    collection_name: str,
+) -> AstraDBByteStore:
+    store = AstraDBByteStore(
+        collection_name=collection_name,
+        token=astra_db_credentials["token"],
+        api_endpoint=astra_db_credentials["api_endpoint"],
+        namespace=astra_db_credentials["namespace"],
+        environment=astra_db_credentials["environment"],
+    )
     store.mset([("key1", b"value1"), ("key2", b"value2")])
     return store
 
 
 async def init_async_store(
-    async_astra_db: AsyncAstraDB, collection_name: str
+    astra_db_credentials: Dict[str, Optional[str]], collection_name: str
 ) -> AstraDBStore:
     store = AstraDBStore(
         collection_name=collection_name,
-        async_astra_db_client=async_astra_db,
+        token=astra_db_credentials["token"],
+        api_endpoint=astra_db_credentials["api_endpoint"],
+        namespace=astra_db_credentials["namespace"],
+        environment=astra_db_credentials["environment"],
         setup_mode=SetupMode.ASYNC,
     )
     await store.amset([("key1", [0.1, 0.2]), ("key2", "value2")])
@@ -63,84 +97,108 @@ async def init_async_store(
 
 @pytest.mark.skipif(not _has_env_vars(), reason="Missing Astra DB env. vars")
 class TestAstraDBStore:
-    def test_mget(self, astra_db: AstraDB) -> None:
+    def test_mget(
+        self,
+        astra_db_credentials: Dict[str, Optional[str]],
+    ) -> None:
         """Test AstraDBStore mget method."""
         collection_name = "lc_test_store_mget"
         try:
-            store = init_store(astra_db, collection_name)
+            store = init_store(astra_db_credentials, collection_name)
             assert store.mget(["key1", "key2"]) == [[0.1, 0.2], "value2"]
         finally:
-            astra_db.delete_collection(collection_name)
+            store.astra_env.database.drop_collection(collection_name)
 
-    async def test_amget(self, async_astra_db: AsyncAstraDB) -> None:
+    async def test_amget(
+        self,
+        astra_db_credentials: Dict[str, Optional[str]],
+    ) -> None:
         """Test AstraDBStore amget method."""
         collection_name = "lc_test_store_mget"
         try:
-            store = await init_async_store(async_astra_db, collection_name)
+            store = await init_async_store(astra_db_credentials, collection_name)
             assert await store.amget(["key1", "key2"]) == [[0.1, 0.2], "value2"]
         finally:
-            await async_astra_db.delete_collection(collection_name)
+            await store.astra_env.async_database.drop_collection(collection_name)
 
-    def test_mset(self, astra_db: AstraDB) -> None:
+    def test_mset(
+        self,
+        astra_db_credentials: Dict[str, Optional[str]],
+    ) -> None:
         """Test that multiple keys can be set with AstraDBStore."""
         collection_name = "lc_test_store_mset"
         try:
-            store = init_store(astra_db, collection_name)
+            store = init_store(astra_db_credentials, collection_name)
             result = store.collection.find_one({"_id": "key1"})
-            assert result["data"]["document"]["value"] == [0.1, 0.2]
+            assert (result or {})["value"] == [0.1, 0.2]
             result = store.collection.find_one({"_id": "key2"})
-            assert result["data"]["document"]["value"] == "value2"
+            assert (result or {})["value"] == "value2"
         finally:
-            astra_db.delete_collection(collection_name)
+            store.astra_env.database.drop_collection(collection_name)
 
-    async def test_amset(self, async_astra_db: AsyncAstraDB) -> None:
+    async def test_amset(
+        self,
+        astra_db_credentials: Dict[str, Optional[str]],
+    ) -> None:
         """Test that multiple keys can be set with AstraDBStore."""
         collection_name = "lc_test_store_mset"
         try:
-            store = await init_async_store(async_astra_db, collection_name)
+            store = await init_async_store(astra_db_credentials, collection_name)
             result = await store.async_collection.find_one({"_id": "key1"})
-            assert result["data"]["document"]["value"] == [0.1, 0.2]
+            assert (result or {})["value"] == [0.1, 0.2]
             result = await store.async_collection.find_one({"_id": "key2"})
-            assert result["data"]["document"]["value"] == "value2"
+            assert (result or {})["value"] == "value2"
         finally:
-            await async_astra_db.delete_collection(collection_name)
+            await store.astra_env.async_database.drop_collection(collection_name)
 
-    def test_mdelete(self, astra_db: AstraDB) -> None:
+    def test_mdelete(
+        self,
+        astra_db_credentials: Dict[str, Optional[str]],
+    ) -> None:
         """Test that deletion works as expected."""
         collection_name = "lc_test_store_mdelete"
         try:
-            store = init_store(astra_db, collection_name)
+            store = init_store(astra_db_credentials, collection_name)
             store.mdelete(["key1", "key2"])
             result = store.mget(["key1", "key2"])
             assert result == [None, None]
         finally:
-            astra_db.delete_collection(collection_name)
+            store.astra_env.database.drop_collection(collection_name)
 
-    async def test_amdelete(self, async_astra_db: AsyncAstraDB) -> None:
+    async def test_amdelete(
+        self,
+        astra_db_credentials: Dict[str, Optional[str]],
+    ) -> None:
         """Test that deletion works as expected."""
         collection_name = "lc_test_store_mdelete"
         try:
-            store = await init_async_store(async_astra_db, collection_name)
+            store = await init_async_store(astra_db_credentials, collection_name)
             await store.amdelete(["key1", "key2"])
             result = await store.amget(["key1", "key2"])
             assert result == [None, None]
         finally:
-            await async_astra_db.delete_collection(collection_name)
+            await store.astra_env.async_database.drop_collection(collection_name)
 
-    def test_yield_keys(self, astra_db: AstraDB) -> None:
+    def test_yield_keys(
+        self,
+        astra_db_credentials: Dict[str, Optional[str]],
+    ) -> None:
         collection_name = "lc_test_store_yield_keys"
         try:
-            store = init_store(astra_db, collection_name)
+            store = init_store(astra_db_credentials, collection_name)
             assert set(store.yield_keys()) == {"key1", "key2"}
             assert set(store.yield_keys(prefix="key")) == {"key1", "key2"}
             assert set(store.yield_keys(prefix="lang")) == set()
         finally:
-            astra_db.delete_collection(collection_name)
+            store.astra_env.database.drop_collection(collection_name)
 
-    async def test_ayield_keys(self, async_astra_db: AsyncAstraDB) -> None:
+    async def test_ayield_keys(
+        self,
+        astra_db_credentials: Dict[str, Optional[str]],
+    ) -> None:
         collection_name = "lc_test_store_yield_keys"
         try:
-            store = await init_async_store(async_astra_db, collection_name)
+            store = await init_async_store(astra_db_credentials, collection_name)
             assert {key async for key in store.ayield_keys()} == {"key1", "key2"}
             assert {key async for key in store.ayield_keys(prefix="key")} == {
                 "key1",
@@ -148,51 +206,143 @@ class TestAstraDBStore:
             }
             assert {key async for key in store.ayield_keys(prefix="lang")} == set()
         finally:
-            await async_astra_db.delete_collection(collection_name)
+            await store.astra_env.async_database.drop_collection(collection_name)
 
-    def test_bytestore_mget(self, astra_db: AstraDB) -> None:
+    def test_bytestore_mget(
+        self,
+        astra_db_credentials: Dict[str, Optional[str]],
+    ) -> None:
         """Test AstraDBByteStore mget method."""
         collection_name = "lc_test_bytestore_mget"
         try:
-            store = init_bytestore(astra_db, collection_name)
+            store = init_bytestore(astra_db_credentials, collection_name)
             assert store.mget(["key1", "key2"]) == [b"value1", b"value2"]
         finally:
-            astra_db.delete_collection(collection_name)
+            store.astra_env.database.drop_collection(collection_name)
 
-    def test_bytestore_mset(self, astra_db: AstraDB) -> None:
+    def test_bytestore_mset(
+        self,
+        astra_db_credentials: Dict[str, Optional[str]],
+    ) -> None:
         """Test that multiple keys can be set with AstraDBByteStore."""
         collection_name = "lc_test_bytestore_mset"
         try:
-            store = init_bytestore(astra_db, collection_name)
+            store = init_bytestore(astra_db_credentials, collection_name)
             result = store.collection.find_one({"_id": "key1"})
-            assert result["data"]["document"]["value"] == "dmFsdWUx"
+            assert (result or {})["value"] == "dmFsdWUx"
             result = store.collection.find_one({"_id": "key2"})
-            assert result["data"]["document"]["value"] == "dmFsdWUy"
+            assert (result or {})["value"] == "dmFsdWUy"
         finally:
-            astra_db.delete_collection(collection_name)
+            store.astra_env.database.drop_collection(collection_name)
 
-    def test_indexing_detection(self, astra_db: AstraDB) -> None:
+    def test_indexing_detection(
+        self,
+        astra_db_credentials: Dict[str, Optional[str]],
+        database: Database,
+    ) -> None:
         """Test the behaviour against preexisting legacy collections."""
-        astra_db.create_collection("lc_test_legacy_store")
-        astra_db.create_collection(
-            "lc_test_custom_store", options={"indexing": {"allow": ["my_field"]}}
+        database.create_collection("lc_test_legacy_store")
+        database.create_collection(
+            "lc_test_custom_store", indexing={"allow": ["my_field"]}
         )
-        AstraDBStore(collection_name="lc_test_regular_store", astra_db_client=astra_db)
+        AstraDBStore(
+            collection_name="lc_test_regular_store",
+            token=astra_db_credentials["token"],
+            api_endpoint=astra_db_credentials["api_endpoint"],
+            namespace=astra_db_credentials["namespace"],
+            environment=astra_db_credentials["environment"],
+        )
 
         # repeated instantiation must work
-        AstraDBStore(collection_name="lc_test_regular_store", astra_db_client=astra_db)
+        AstraDBStore(
+            collection_name="lc_test_regular_store",
+            token=astra_db_credentials["token"],
+            api_endpoint=astra_db_credentials["api_endpoint"],
+            namespace=astra_db_credentials["namespace"],
+            environment=astra_db_credentials["environment"],
+        )
         # on a legacy collection must just give a warning
         with pytest.warns(UserWarning) as rec_warnings:
             AstraDBStore(
-                collection_name="lc_test_legacy_store", astra_db_client=astra_db
+                collection_name="lc_test_legacy_store",
+                token=astra_db_credentials["token"],
+                api_endpoint=astra_db_credentials["api_endpoint"],
+                namespace=astra_db_credentials["namespace"],
+                environment=astra_db_credentials["environment"],
             )
             assert len(rec_warnings) == 1
         # on a custom collection must error
         with pytest.raises(ValueError):
             AstraDBStore(
-                collection_name="lc_test_custom_store", astra_db_client=astra_db
+                collection_name="lc_test_custom_store",
+                token=astra_db_credentials["token"],
+                api_endpoint=astra_db_credentials["api_endpoint"],
+                namespace=astra_db_credentials["namespace"],
+                environment=astra_db_credentials["environment"],
             )
 
-        astra_db.delete_collection("lc_test_legacy_store")
-        astra_db.delete_collection("lc_test_custom_store")
-        astra_db.delete_collection("lc_test_regular_store")
+        database.drop_collection("lc_test_legacy_store")
+        database.drop_collection("lc_test_custom_store")
+        database.drop_collection("lc_test_regular_store")
+
+    @pytest.mark.skipif(
+        os.environ.get("ASTRA_DB_ENVIRONMENT", "prod").upper() != "PROD",
+        reason="Can run on Astra DB prod only",
+    )
+    def test_store_coreclients_init_sync(
+        self,
+        astra_db_credentials: Dict[str, Optional[str]],
+        core_astra_db: AstraDB,
+    ) -> None:
+        """A deprecation warning from passing a (core) AstraDB, but it works."""
+        collection_name = "lc_test_bytestore_coreclsync"
+        try:
+            store_init_ok = AstraDBStore(
+                collection_name=collection_name,
+                token=astra_db_credentials["token"],
+                api_endpoint=astra_db_credentials["api_endpoint"],
+                namespace=astra_db_credentials["namespace"],
+            )
+            store_init_ok.mset([("key", "val123")])
+            # create an equivalent store with core AstraDB in init
+            with pytest.warns(DeprecationWarning) as rec_warnings:
+                store_init_core = AstraDBStore(
+                    collection_name=collection_name,
+                    astra_db_client=core_astra_db,
+                )
+                assert len(rec_warnings) == 1
+                assert store_init_core.mget(["key"]) == ["val123"]
+        finally:
+            store_init_ok.astra_env.database.drop_collection(collection_name)
+
+    @pytest.mark.skipif(
+        os.environ.get("ASTRA_DB_ENVIRONMENT", "prod").upper() != "PROD",
+        reason="Can run on Astra DB prod only",
+    )
+    async def test_store_coreclients_init_async(
+        self,
+        astra_db_credentials: Dict[str, Optional[str]],
+        core_astra_db: AstraDB,
+    ) -> None:
+        """A deprecation warning from passing a (core) AstraDB, but it works."""
+        collection_name = "lc_test_bytestore_coreclasync"
+        try:
+            store_init_ok = AstraDBStore(
+                collection_name=collection_name,
+                token=astra_db_credentials["token"],
+                api_endpoint=astra_db_credentials["api_endpoint"],
+                namespace=astra_db_credentials["namespace"],
+                setup_mode=SetupMode.ASYNC,
+            )
+            await store_init_ok.amset([("key", "val123")])
+            # create an equivalent store with core AstraDB in init
+            with pytest.warns(DeprecationWarning) as rec_warnings:
+                store_init_core = AstraDBStore(
+                    collection_name=collection_name,
+                    astra_db_client=core_astra_db,
+                    setup_mode=SetupMode.ASYNC,
+                )
+                assert len(rec_warnings) == 1
+                assert await store_init_core.amget(["key"]) == ["val123"]
+        finally:
+            await store_init_ok.astra_env.async_database.drop_collection(collection_name)

--- a/libs/astradb/tests/integration_tests/test_storage.py
+++ b/libs/astradb/tests/integration_tests/test_storage.py
@@ -11,7 +11,7 @@ from astrapy.db import AstraDB
 from langchain_astradb.storage import AstraDBByteStore, AstraDBStore
 from langchain_astradb.utils.astradb import SetupMode
 
-from .conftest import _has_env_vars
+from .conftest import _has_env_vars, AstraDBCredentials
 
 
 def init_store(

--- a/libs/astradb/tests/integration_tests/test_storage.py
+++ b/libs/astradb/tests/integration_tests/test_storage.py
@@ -11,7 +11,7 @@ from astrapy.db import AstraDB
 from langchain_astradb.storage import AstraDBByteStore, AstraDBStore
 from langchain_astradb.utils.astradb import SetupMode
 
-from .conftest import _has_env_vars, AstraDBCredentials
+from .conftest import _has_env_vars
 
 
 def init_store(

--- a/libs/astradb/tests/integration_tests/test_vectorstores.py
+++ b/libs/astradb/tests/integration_tests/test_vectorstores.py
@@ -157,6 +157,9 @@ def vectorize_store(
     """
     astra db vector store with server-side embeddings using openai + shared_secret
     """
+    if "SHARED_SECRET_NAME_OPENAI" not in os.environ:
+        pytest.skip("OpenAI SHARED_SECRET key not set for KMS vectorize")
+
     v_store = AstraDBVectorStore(
         collection_vector_service_options=openai_vectorize_options,
         collection_name=COLLECTION_NAME_VECTORIZE_OPENAI,

--- a/libs/astradb/tests/integration_tests/test_vectorstores.py
+++ b/libs/astradb/tests/integration_tests/test_vectorstores.py
@@ -287,12 +287,13 @@ class TestAstraDBVectorStore:
     ) -> None:
         """Create and delete with vectorize option."""
         v_store = AstraDBVectorStore(
-            collection_vector_service_options=openai_vectorize_options,
-            collection_name=COLLECTION_NAME_VECTORIZE_OPENAI,
+            collection_vector_service_options=openai_vectorize_options_header,
+            collection_name=COLLECTION_NAME_VECTORIZE_OPENAI_HEADER,
             token=astra_db_credentials["token"],
             api_endpoint=astra_db_credentials["api_endpoint"],
             namespace=astra_db_credentials["namespace"],
             environment=astra_db_credentials["environment"],
+            collection_embedding_api_key=os.environ["OPENAI_API_KEY"],
         )
         v_store.add_texts(["Sample 1"])
         v_store.delete_collection()
@@ -464,8 +465,9 @@ class TestAstraDBVectorStore:
     ) -> None:
         """from_texts and from_documents methods with vectorize."""
         AstraDBVectorStore(
-            collection_vector_service_options=openai_vectorize_options,
-            collection_name=COLLECTION_NAME_VECTORIZE_OPENAI,
+            collection_vector_service_options=openai_vectorize_options_header,
+            collection_embedding_api_key=os.environ["OPENAI_API_KEY"],
+            collection_name=COLLECTION_NAME_VECTORIZE_OPENAI_HEADER,
             token=astra_db_credentials["token"],
             api_endpoint=astra_db_credentials["api_endpoint"],
             namespace=astra_db_credentials["namespace"],
@@ -475,8 +477,9 @@ class TestAstraDBVectorStore:
         # from_texts
         v_store = AstraDBVectorStore.from_texts(
             texts=["Hi", "Ho"],
-            collection_vector_service_options=openai_vectorize_options,
-            collection_name=COLLECTION_NAME_VECTORIZE_OPENAI,
+            collection_vector_service_options=openai_vectorize_options_header,
+            collection_embedding_api_key=os.environ["OPENAI_API_KEY"],
+            collection_name=COLLECTION_NAME_VECTORIZE_OPENAI_HEADER,
             token=astra_db_credentials["token"],
             api_endpoint=astra_db_credentials["api_endpoint"],
             namespace=astra_db_credentials["namespace"],
@@ -493,8 +496,9 @@ class TestAstraDBVectorStore:
                 Document(page_content="Hee"),
                 Document(page_content="Hoi"),
             ],
-            collection_vector_service_options=openai_vectorize_options,
-            collection_name=COLLECTION_NAME_VECTORIZE_OPENAI,
+            collection_vector_service_options=openai_vectorize_options_header,
+            collection_embedding_api_key=os.environ["OPENAI_API_KEY"],
+            collection_name=COLLECTION_NAME_VECTORIZE_OPENAI_HEADER,
             token=astra_db_credentials["token"],
             api_endpoint=astra_db_credentials["api_endpoint"],
             namespace=astra_db_credentials["namespace"],
@@ -567,8 +571,9 @@ class TestAstraDBVectorStore:
         # from_text with vectorize
         v_store = await AstraDBVectorStore.afrom_texts(
             texts=["Haa", "Huu"],
-            collection_vector_service_options=openai_vectorize_options,
-            collection_name=COLLECTION_NAME_VECTORIZE_OPENAI,
+            collection_vector_service_options=openai_vectorize_options_header,
+            collection_embedding_api_key=os.environ["OPENAI_API_KEY"],
+            collection_name=COLLECTION_NAME_VECTORIZE_OPENAI_HEADER,
             token=astra_db_credentials["token"],
             api_endpoint=astra_db_credentials["api_endpoint"],
             namespace=astra_db_credentials["namespace"],
@@ -587,8 +592,9 @@ class TestAstraDBVectorStore:
                 Document(page_content="HeeH"),
                 Document(page_content="HooH"),
             ],
-            collection_vector_service_options=openai_vectorize_options,
-            collection_name=COLLECTION_NAME_VECTORIZE_OPENAI,
+            collection_vector_service_options=openai_vectorize_options_header,
+            collection_embedding_api_key=os.environ["OPENAI_API_KEY"],
+            collection_name=COLLECTION_NAME_VECTORIZE_OPENAI_HEADER,
             token=astra_db_credentials["token"],
             api_endpoint=astra_db_credentials["api_endpoint"],
             namespace=astra_db_credentials["namespace"],

--- a/libs/astradb/tests/unit_tests/test_astra_db_environment.py
+++ b/libs/astradb/tests/unit_tests/test_astra_db_environment.py
@@ -1,7 +1,7 @@
 import os
-from unittest.mock import Mock
 
 import pytest
+from astrapy.db import AstraDB
 
 from langchain_astradb.utils.astradb import (
     API_ENDPOINT_ENV_VAR,
@@ -15,135 +15,202 @@ class TestAstraDBEnvironment:
     def test_initialization(self) -> None:
         """Test the various ways to initialize the environment."""
 
-        # clean environment
-        if TOKEN_ENV_VAR in os.environ:
+        a_e_string = (
+            "https://01234567-89ab-cdef-0123-456789abcdef-us-east1"
+            ".apps.astra.datastax.com"
+        )
+        a_e_string_2 = (
+            "https://98765432-10fe-dcba-9876-543210fedcba-us-east1"
+            ".apps.astra.datastax.com"
+        )
+        mock_astra_db = AstraDB(
+            token="t",
+            api_endpoint=a_e_string,
+            namespace="n",
+        )
+
+        ENV_VARS_TO_RESTORE = {}
+        try:
+            # clean environment
+            if TOKEN_ENV_VAR in os.environ:
+                ENV_VARS_TO_RESTORE[TOKEN_ENV_VAR] = os.environ[TOKEN_ENV_VAR]
+                del os.environ[TOKEN_ENV_VAR]
+            if API_ENDPOINT_ENV_VAR in os.environ:
+                ENV_VARS_TO_RESTORE[API_ENDPOINT_ENV_VAR] = os.environ[
+                    API_ENDPOINT_ENV_VAR
+                ]
+                del os.environ[API_ENDPOINT_ENV_VAR]
+            if NAMESPACE_ENV_VAR in os.environ:
+                ENV_VARS_TO_RESTORE[NAMESPACE_ENV_VAR] = os.environ[
+                    NAMESPACE_ENV_VAR
+                ]
+                del os.environ[NAMESPACE_ENV_VAR]
+
+            # token+endpoint
+            env1 = _AstraDBEnvironment(
+                token="t",
+                api_endpoint=a_e_string,
+                namespace="n",
+            )
+
+            # through a core AstraDB instance
+            env2 = _AstraDBEnvironment(astra_db_client=mock_astra_db)
+
+            assert env1.data_api_client == env2.data_api_client
+            assert env1.database == env2.database
+            assert env1.async_database == env2.async_database
+
+            # token+endpoint, but also a ready-made client
+            with pytest.raises(ValueError):
+                _AstraDBEnvironment(
+                    token="t",
+                    api_endpoint=a_e_string,
+                    astra_db_client=mock_astra_db,
+                )
+            with pytest.raises(ValueError):
+                _AstraDBEnvironment(
+                    token="t",
+                    api_endpoint=a_e_string,
+                    async_astra_db_client=mock_astra_db.to_async(),
+                )
+
+            # just tokenn, no endpoint
+            with pytest.raises(ValueError):
+                _AstraDBEnvironment(
+                    token="t",
+                )
+
+            # just client(s)
+            env3 = _AstraDBEnvironment(
+                async_astra_db_client=mock_astra_db.to_async(),
+            )
+            assert env1.data_api_client == env3.data_api_client
+            assert env1.database == env3.database
+            assert env1.async_database == env3.async_database
+
+            # both sync and async (matching)
+            _AstraDBEnvironment(
+                astra_db_client=mock_astra_db,
+                async_astra_db_client=mock_astra_db.to_async(),
+            )
+
+            # both sync and async, but mismatching in various ways
+            with pytest.raises(ValueError):
+                _AstraDBEnvironment(
+                    async_astra_db_client=mock_astra_db.to_async(),
+                    astra_db_client=AstraDB(
+                        token="t",
+                        api_endpoint=a_e_string_2,
+                        namespace="n",
+                    ),
+                )
+            with pytest.raises(ValueError):
+                _AstraDBEnvironment(
+                    async_astra_db_client=mock_astra_db.to_async(),
+                    astra_db_client=AstraDB(
+                        token="t",
+                        api_endpoint=a_e_string,
+                        namespace="n2",
+                    ),
+                )
+            with pytest.raises(ValueError):
+                _AstraDBEnvironment(
+                    async_astra_db_client=mock_astra_db.to_async(),
+                    astra_db_client=AstraDB(
+                        token="t2",
+                        api_endpoint=a_e_string,
+                        namespace="n",
+                    ),
+                )
+
+            # token+client
+            with pytest.raises(ValueError):
+                _AstraDBEnvironment(
+                    token="t",
+                    astra_db_client=mock_astra_db,
+                )
+            # endpoint+client
+            with pytest.raises(ValueError):
+                _AstraDBEnvironment(
+                    api_endpoint=a_e_string,
+                    async_astra_db_client=mock_astra_db.to_async(),
+                )
+
+            # token via environment variable:
+            os.environ[TOKEN_ENV_VAR] = "t"
+            env4 = _AstraDBEnvironment(
+                api_endpoint=a_e_string,
+                namespace="n",
+            )
             del os.environ[TOKEN_ENV_VAR]
-        if API_ENDPOINT_ENV_VAR in os.environ:
+            assert env1.data_api_client == env4.data_api_client
+            assert env1.database == env4.database
+            assert env1.async_database == env4.async_database
+
+            # endpoint via environment variable:
+            os.environ[API_ENDPOINT_ENV_VAR] = a_e_string
+            env5 = _AstraDBEnvironment(
+                token="t",
+                namespace="n",
+            )
             del os.environ[API_ENDPOINT_ENV_VAR]
-        if NAMESPACE_ENV_VAR in os.environ:
+            assert env1.data_api_client == env5.data_api_client
+            assert env1.database == env5.database
+            assert env1.async_database == env5.async_database
+
+            # both and also namespace via env vars
+            os.environ[TOKEN_ENV_VAR] = "t"
+            os.environ[API_ENDPOINT_ENV_VAR] = a_e_string
+            os.environ[NAMESPACE_ENV_VAR] = "n"
+            env6 = _AstraDBEnvironment()
+            assert env1.data_api_client == env6.data_api_client
+            assert env1.database == env6.database
+            assert env1.async_database == env6.async_database
+            del os.environ[TOKEN_ENV_VAR]
+            del os.environ[API_ENDPOINT_ENV_VAR]
             del os.environ[NAMESPACE_ENV_VAR]
 
-        # token+endpoint
-        env1 = _AstraDBEnvironment(
-            token="t",
-            api_endpoint="ae",
-        )
-        assert env1.async_astra_db.token == "t"
-        assert env1.async_astra_db.api_endpoint == "ae"
+            # env vars do not interfere if client(s) passed
+            os.environ[TOKEN_ENV_VAR] = "NO!"
+            os.environ[API_ENDPOINT_ENV_VAR] = "NO!"
+            os.environ[NAMESPACE_ENV_VAR] = "NO!"
+            env7a = _AstraDBEnvironment(
+                async_astra_db_client=mock_astra_db.to_async(),
+            )
+            env7b = _AstraDBEnvironment(
+                astra_db_client=mock_astra_db,
+            )
+            env7c = _AstraDBEnvironment(
+                astra_db_client=mock_astra_db,
+                async_astra_db_client=mock_astra_db.to_async(),
+            )
+            assert env1.data_api_client == env7a.data_api_client
+            assert env1.database == env7a.database
+            assert env1.async_database == env7a.async_database
+            assert env1.data_api_client == env7b.data_api_client
+            assert env1.database == env7b.database
+            assert env1.async_database == env7b.async_database
+            assert env1.data_api_client == env7c.data_api_client
+            assert env1.database == env7c.database
+            assert env1.async_database == env7c.async_database
 
-        # token+endpoint, but also a ready-made client
-        with pytest.raises(ValueError):
-            _AstraDBEnvironment(
+            # env. vars do not interfere if parameters passed
+            env8 = _AstraDBEnvironment(
                 token="t",
-                api_endpoint="ae",
-                astra_db_client=Mock(),
+                api_endpoint=a_e_string,
+                namespace="n",
             )
-        with pytest.raises(ValueError):
-            _AstraDBEnvironment(
-                token="t",
-                api_endpoint="ae",
-                async_astra_db_client=Mock(),
-            )
+            assert env1.data_api_client == env8.data_api_client
+            assert env1.database == env8.database
+            assert env1.async_database == env8.async_database
 
-        # just token or endpoint
-        with pytest.raises(ValueError):
-            _AstraDBEnvironment(
-                token="t",
-            )
-        with pytest.raises(ValueError):
-            _AstraDBEnvironment(
-                api_endpoint="ae",
-            )
-
-        # just client(s)
-        _AstraDBEnvironment(
-            async_astra_db_client=Mock(),
-        )
-        _AstraDBEnvironment(
-            astra_db_client=Mock(),
-        )
-        _AstraDBEnvironment(
-            astra_db_client=Mock(),
-            async_astra_db_client=Mock(),
-        )
-
-        # token+client
-        with pytest.raises(ValueError):
-            _AstraDBEnvironment(
-                token="t",
-                astra_db_client=Mock(),
-            )
-        # endpoint+client
-        with pytest.raises(ValueError):
-            _AstraDBEnvironment(
-                api_endpoint="ae",
-                async_astra_db_client=Mock(),
-            )
-
-        # token via environment variable:
-        os.environ[TOKEN_ENV_VAR] = "T"
-        env3 = _AstraDBEnvironment(
-            api_endpoint="ae",
-        )
-        assert env3.async_astra_db.token == "T"
-        assert env3.async_astra_db.api_endpoint == "ae"
-
-        # endpoint via environment variable:
-        del os.environ[TOKEN_ENV_VAR]
-        os.environ[API_ENDPOINT_ENV_VAR] = "AE"
-        env4 = _AstraDBEnvironment(
-            token="t",
-        )
-        assert env4.async_astra_db.token == "t"
-        assert env4.async_astra_db.api_endpoint == "AE"
-
-        # both via env vars
-        os.environ[TOKEN_ENV_VAR] = "T"
-        os.environ[API_ENDPOINT_ENV_VAR] = "AE"
-        env5 = _AstraDBEnvironment()
-        assert env5.async_astra_db.token == "T"
-        assert env5.async_astra_db.api_endpoint == "AE"
-
-        # env vars do not interfere if client(s) passed
-        env6a = _AstraDBEnvironment(
-            async_astra_db_client=Mock(),
-        )
-        env6b = _AstraDBEnvironment(
-            astra_db_client=Mock(),
-        )
-        env6c = _AstraDBEnvironment(
-            astra_db_client=Mock(),
-            async_astra_db_client=Mock(),
-        )
-        assert env6a.astra_db.token != "T"
-        assert env6b.astra_db.token != "T"
-        assert env6c.astra_db.token != "T"
-        assert env6a.astra_db.api_endpoint != "AE"
-        assert env6b.astra_db.api_endpoint != "AE"
-        assert env6c.astra_db.api_endpoint != "AE"
-
-        # env. vars do not interfere if parameters passed
-        env7a = _AstraDBEnvironment(
-            token="t",
-            api_endpoint="ae",
-        )
-        assert env7a.async_astra_db.token == "t"
-        assert env7a.async_astra_db.api_endpoint == "ae"
-        env7b = _AstraDBEnvironment(
-            api_endpoint="ae",
-        )
-        assert env7b.async_astra_db.token == "T"
-        assert env7b.async_astra_db.api_endpoint == "ae"
-        env7c = _AstraDBEnvironment(
-            token="t",
-        )
-        assert env7c.async_astra_db.token == "t"
-        assert env7c.async_astra_db.api_endpoint == "AE"
-
-        # namespaces through env. vars
-        os.environ[NAMESPACE_ENV_VAR] = "NS"
-        env8 = _AstraDBEnvironment(
-            token="t",
-            api_endpoint="ae",
-        )
-        assert env8.astra_db.namespace == "NS"
+        finally:
+            # reinstate the env. variables to what they were before this test:
+            if TOKEN_ENV_VAR in os.environ:
+                del os.environ[TOKEN_ENV_VAR]
+            if API_ENDPOINT_ENV_VAR in os.environ:
+                del os.environ[API_ENDPOINT_ENV_VAR]
+            if NAMESPACE_ENV_VAR in os.environ:
+                del os.environ[NAMESPACE_ENV_VAR]
+            for ENV_VAR_NAME, ENV_VAR_VALUE in ENV_VARS_TO_RESTORE.items():
+                os.environ[ENV_VAR_NAME] = ENV_VAR_VALUE

--- a/libs/astradb/tests/unit_tests/test_astra_db_environment.py
+++ b/libs/astradb/tests/unit_tests/test_astra_db_environment.py
@@ -41,9 +41,7 @@ class TestAstraDBEnvironment:
                 ]
                 del os.environ[API_ENDPOINT_ENV_VAR]
             if NAMESPACE_ENV_VAR in os.environ:
-                ENV_VARS_TO_RESTORE[NAMESPACE_ENV_VAR] = os.environ[
-                    NAMESPACE_ENV_VAR
-                ]
+                ENV_VARS_TO_RESTORE[NAMESPACE_ENV_VAR] = os.environ[NAMESPACE_ENV_VAR]
                 del os.environ[NAMESPACE_ENV_VAR]
 
             # token+endpoint

--- a/libs/astradb/tests/unit_tests/test_vectorstores.py
+++ b/libs/astradb/tests/unit_tests/test_vectorstores.py
@@ -1,77 +1,82 @@
-from typing import List
-from unittest.mock import Mock
-
 import pytest
+from astrapy.db import AstraDB
 from astrapy.info import CollectionVectorServiceOptions
-from langchain_core.embeddings import Embeddings
 
+from langchain_astradb.utils.astradb import SetupMode
 from langchain_astradb.vectorstores import (
     DEFAULT_INDEXING_OPTIONS,
     AstraDBVectorStore,
 )
 
-
-class SomeEmbeddings(Embeddings):
-    """
-    Turn a sentence into an embedding vector in some way.
-    Not important how. It is deterministic is all that counts.
-    """
-
-    def __init__(self, dimension: int) -> None:
-        self.dimension = dimension
-
-    def embed_documents(self, texts: List[str]) -> List[List[float]]:
-        return [self.embed_query(txt) for txt in texts]
-
-    async def aembed_documents(self, texts: List[str]) -> List[List[float]]:
-        return self.embed_documents(texts)
-
-    def embed_query(self, text: str) -> List[float]:
-        unnormed0 = [ord(c) for c in text[: self.dimension]]
-        unnormed = (unnormed0 + [1] + [0] * (self.dimension - 1 - len(unnormed0)))[
-            : self.dimension
-        ]
-        norm = sum(x * x for x in unnormed) ** 0.5
-        normed = [x / norm for x in unnormed]
-        return normed
-
-    async def aembed_query(self, text: str) -> List[float]:
-        return self.embed_query(text)
+from ..conftest import SomeEmbeddings
 
 
 class TestAstraDB:
     def test_initialization(self) -> None:
-        """Test integration vectorstore initialization."""
-        mock_astra_db = Mock()
+        """Unit test of vector store initialization modes."""
+
+        # Using a 'core' AstraDB class (as opposed to secret-based)
+        a_e_string = (
+            "https://01234567-89ab-cdef-0123-456789abcdef-us-east1"
+            ".apps.astra.datastax.com"
+        )
+        mock_astra_db = AstraDB(
+            token="t",
+            api_endpoint=a_e_string,
+            namespace="n",
+        )
         embedding = SomeEmbeddings(dimension=2)
+        with pytest.warns(DeprecationWarning):
+            AstraDBVectorStore(
+                embedding=embedding,
+                collection_name="mock_coll_name",
+                astra_db_client=mock_astra_db,
+                setup_mode=SetupMode.OFF,
+            )
+
+        # With an embedding class
         AstraDBVectorStore(
-            embedding=embedding,
             collection_name="mock_coll_name",
-            astra_db_client=mock_astra_db,
+            token="t",
+            api_endpoint=a_e_string,
+            namespace="n",
+            embedding=embedding,
+            setup_mode=SetupMode.OFF,
         )
 
-        # Test with server-side embeddings
+        # With server-side embeddings ('vectorize')
         vector_options = CollectionVectorServiceOptions(
             provider="test", model_name="test"
         )
         AstraDBVectorStore(
             collection_name="mock_coll_name",
-            astra_db_client=mock_astra_db,
+            token="t",
+            api_endpoint=a_e_string,
+            namespace="n",
             collection_vector_service_options=vector_options,
+            setup_mode=SetupMode.OFF,
         )
 
+        # embedding and vectorize => error
         with pytest.raises(ValueError):
             AstraDBVectorStore(
                 embedding=embedding,
                 collection_name="mock_coll_name",
-                astra_db_client=mock_astra_db,
+                token="t",
+                api_endpoint=a_e_string,
+                namespace="n",
                 collection_vector_service_options=vector_options,
+                setup_mode=SetupMode.OFF,
             )
 
+        # no embedding and no vectorize => error
         with pytest.raises(ValueError):
             AstraDBVectorStore(
                 collection_name="mock_coll_name",
-                astra_db_client=mock_astra_db,
+                token="t",
+                api_endpoint=a_e_string,
+                namespace="n",
+                setup_mode=SetupMode.OFF,
             )
 
     def test_astradb_vectorstore_unit_indexing_normalization(self) -> None:


### PR DESCRIPTION
This is a large rewrite of the internals in order to completely migrate to using the recent, idiomatic astrapy.

### Motivation

- enabling non-Astra Data API (such as HCD. I could run all integration testing on HCD as well)
- simplify most of the Data API newer features (such as $vectorize)
- use an astrapy API that is extensively documented and actively maintained

### Guide to the PR

All the newest astrapy things are now usable (e.g. environments, TokenProvider, EmbeddingHeaderProvider classes and so on).

Along the way, several improvements came along:

- deprecating (but still 100% working) passing "clients" to the constructors. Preferred: secret/strings in init methods
- issuing warning if "legacy" parameters are used (as part of the full alignment to the modern astrapy). But without  breaking changes. Everything is 100% compatible with previous usage patterns
- reorganization/modernization of the whole test suite (fixture re-use, uniform test function scheme, etc)
- more testing added, esp. thoroughly probing the (totally rewritten) insert-very-many-with-possible-overwrite flows (sync/async)

### Notes

1. The internals have changed a lot. Hence, code that directly uses the internals of these classes (e.g. using `vector_store.collection`) would stop working. Such usage, anyway, is brittle in the first place and should not be encouraged.
2. The document loader maintains the same signature, including its `nb_prefetched` parameter, which however is ignored - actually a warning is emitted if a prefetch is requested. This reflects the fact that prefetched finds have been found to be problematic in some corner cases on AstraPy and are at the moment disabled. Functionally, this has no effect on the document loader class.
