### PR TITLE
Use future annotations

### DIFF
--- a/libs/astradb/langchain_astradb/chat_message_histories.py
+++ b/libs/astradb/langchain_astradb/chat_message_histories.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import json
 import time
-from typing import List, Optional, Sequence, Union
+from typing import Sequence
 
 from astrapy.authentication import TokenProvider
 from astrapy.db import AstraDB, AsyncAstraDB
@@ -28,12 +28,12 @@ class AstraDBChatMessageHistory(BaseChatMessageHistory):
         *,
         session_id: str,
         collection_name: str = DEFAULT_COLLECTION_NAME,
-        token: Optional[Union[str, TokenProvider]] = None,
-        api_endpoint: Optional[str] = None,
-        environment: Optional[str] = None,
-        astra_db_client: Optional[AstraDB] = None,
-        async_astra_db_client: Optional[AsyncAstraDB] = None,
-        namespace: Optional[str] = None,
+        token: str | TokenProvider | None = None,
+        api_endpoint: str | None = None,
+        environment: str | None = None,
+        astra_db_client: AstraDB | None = None,
+        async_astra_db_client: AsyncAstraDB | None = None,
+        namespace: str | None = None,
         setup_mode: SetupMode = SetupMode.SYNC,
         pre_delete_collection: bool = False,
     ) -> None:
@@ -86,7 +86,7 @@ class AstraDBChatMessageHistory(BaseChatMessageHistory):
         self.collection_name = collection_name
 
     @property
-    def messages(self) -> List[BaseMessage]:
+    def messages(self) -> list[BaseMessage]:
         """Retrieve all session messages from DB"""
         self.astra_env.ensure_db_setup()
         message_blobs = [
@@ -109,10 +109,10 @@ class AstraDBChatMessageHistory(BaseChatMessageHistory):
         return messages
 
     @messages.setter
-    def messages(self, messages: List[BaseMessage]) -> None:
+    def messages(self, messages: list[BaseMessage]) -> None:
         raise NotImplementedError("Use add_messages instead")
 
-    async def aget_messages(self) -> List[BaseMessage]:
+    async def aget_messages(self) -> list[BaseMessage]:
         await self.astra_env.aensure_db_setup()
         docs = self.async_collection.find(
             filter={

--- a/libs/astradb/langchain_astradb/document_loaders.py
+++ b/libs/astradb/langchain_astradb/document_loaders.py
@@ -7,11 +7,7 @@ from typing import (
     Any,
     AsyncIterator,
     Callable,
-    Dict,
     Iterator,
-    List,
-    Optional,
-    Union,
 )
 
 from astrapy.authentication import TokenProvider
@@ -34,19 +30,19 @@ class AstraDBLoader(BaseLoader):
         self,
         collection_name: str,
         *,
-        token: Optional[Union[str, TokenProvider]] = None,
-        api_endpoint: Optional[str] = None,
-        environment: Optional[str] = None,
-        astra_db_client: Optional[AstraDB] = None,
-        async_astra_db_client: Optional[AsyncAstraDB] = None,
-        namespace: Optional[str] = None,
-        filter_criteria: Optional[Dict[str, Any]] = None,
-        projection: Optional[Dict[str, Any]] = _NOT_SET,  # type: ignore[assignment]
-        find_options: Optional[Dict[str, Any]] = None,
-        limit: Optional[int] = None,
+        token: str | TokenProvider | None = None,
+        api_endpoint: str | None = None,
+        environment: str | None = None,
+        astra_db_client: AstraDB | None = None,
+        async_astra_db_client: AsyncAstraDB | None = None,
+        namespace: str | None = None,
+        filter_criteria: dict[str, Any] | None = None,
+        projection: dict[str, Any] | None = _NOT_SET,  # type: ignore[assignment]
+        find_options: dict[str, Any] | None = None,
+        limit: int | None = None,
         nb_prefetched: int = _NOT_SET,  # type: ignore[assignment]
-        page_content_mapper: Callable[[Dict], str] = json.dumps,
-        metadata_mapper: Optional[Callable[[Dict], Dict[str, Any]]] = None,
+        page_content_mapper: Callable[[dict], str] = json.dumps,
+        metadata_mapper: Callable[[dict], dict[str, Any]] | None = None,
     ) -> None:
         """Load DataStax Astra DB documents.
 
@@ -99,7 +95,7 @@ class AstraDBLoader(BaseLoader):
         )
         self.astra_db_env = astra_db_env
         self.filter = filter_criteria
-        self._projection: Optional[Dict[str, Any]] = (
+        self._projection: dict[str, Any] | None = (
             projection if projection is not _NOT_SET else {"*": True}
         )
         # warning if 'prefetched' passed
@@ -150,7 +146,7 @@ class AstraDBLoader(BaseLoader):
             }
         )
 
-    def _to_langchain_doc(self, doc: Dict[str, Any]) -> Document:
+    def _to_langchain_doc(self, doc: dict[str, Any]) -> Document:
         return Document(
             page_content=self.page_content_mapper(doc),
             metadata=self.metadata_mapper(doc),
@@ -166,7 +162,7 @@ class AstraDBLoader(BaseLoader):
         ):
             yield self._to_langchain_doc(doc)
 
-    async def aload(self) -> List[Document]:
+    async def aload(self) -> list[Document]:
         """Load data into Document objects."""
         return [doc async for doc in self.alazy_load()]
 

--- a/libs/astradb/langchain_astradb/utils/astradb.py
+++ b/libs/astradb/langchain_astradb/utils/astradb.py
@@ -8,7 +8,7 @@ import os
 import warnings
 from asyncio import InvalidStateError, Task
 from enum import Enum
-from typing import Any, Awaitable, Dict, List, Optional, Union
+from typing import Any, Awaitable
 
 import langchain_core
 from astrapy import AsyncDatabase, DataAPIClient, Database
@@ -43,17 +43,17 @@ class SetupMode(Enum):
 class _AstraDBEnvironment:
     def __init__(
         self,
-        token: Optional[Union[str, TokenProvider]] = None,
-        api_endpoint: Optional[str] = None,
-        environment: Optional[str] = None,
-        astra_db_client: Optional[AstraDB] = None,
-        async_astra_db_client: Optional[AsyncAstraDB] = None,
-        namespace: Optional[str] = None,
+        token: str | TokenProvider | None = None,
+        api_endpoint: str | None = None,
+        environment: str | None = None,
+        astra_db_client: AstraDB | None = None,
+        async_astra_db_client: AsyncAstraDB | None = None,
+        namespace: str | None = None,
     ) -> None:
-        self.token: Optional[Union[str, TokenProvider]]
-        self.api_endpoint: Optional[str]
-        self.namespace: Optional[str]
-        self.environment: Optional[str]
+        self.token: str | TokenProvider | None
+        self.api_endpoint: str | None
+        self.namespace: str | None
+        self.environment: str | None
 
         self.data_api_client: DataAPIClient
         self.database: Database
@@ -133,7 +133,7 @@ class _AstraDBEnvironment:
             self.api_endpoint = _api_endpoints[0]
             self.namespace = _namespaces[0]
         else:
-            _token: Optional[Union[str, TokenProvider]]
+            _token: str | TokenProvider | None
             # secrets-based initialization
             if token is None:
                 logger.info(
@@ -192,24 +192,20 @@ class _AstraDBCollectionEnvironment(_AstraDBEnvironment):
     def __init__(
         self,
         collection_name: str,
-        token: Optional[Union[str, TokenProvider]] = None,
-        api_endpoint: Optional[str] = None,
-        environment: Optional[str] = None,
-        astra_db_client: Optional[AstraDB] = None,
-        async_astra_db_client: Optional[AsyncAstraDB] = None,
-        namespace: Optional[str] = None,
+        token: str | TokenProvider | None = None,
+        api_endpoint: str | None = None,
+        environment: str | None = None,
+        astra_db_client: AstraDB | None = None,
+        async_astra_db_client: AsyncAstraDB | None = None,
+        namespace: str | None = None,
         setup_mode: SetupMode = SetupMode.SYNC,
         pre_delete_collection: bool = False,
-        embedding_dimension: Union[int, Awaitable[int], None] = None,
-        metric: Optional[str] = None,
-        requested_indexing_policy: Optional[Dict[str, Any]] = None,
-        default_indexing_policy: Optional[Dict[str, Any]] = None,
-        collection_vector_service_options: Optional[
-            CollectionVectorServiceOptions
-        ] = None,
-        collection_embedding_api_key: Optional[
-            Union[str, EmbeddingHeadersProvider]
-        ] = None,
+        embedding_dimension: int | Awaitable[int] | None = None,
+        metric: str | None = None,
+        requested_indexing_policy: dict[str, Any] | None = None,
+        default_indexing_policy: dict[str, Any] | None = None,
+        collection_vector_service_options: CollectionVectorServiceOptions | None = None,
+        collection_embedding_api_key: str | EmbeddingHeadersProvider | None = None,
     ) -> None:
         super().__init__(
             token=token,
@@ -226,7 +222,7 @@ class _AstraDBCollectionEnvironment(_AstraDBEnvironment):
         )
         self.async_collection = self.collection.to_async()
 
-        self.async_setup_db_task: Optional[Task] = None
+        self.async_setup_db_task: Task | None = None
         if setup_mode == SetupMode.ASYNC:
             async_database = self.async_database
 
@@ -299,10 +295,10 @@ class _AstraDBCollectionEnvironment(_AstraDBEnvironment):
 
     @staticmethod
     def _validate_indexing_policy(
-        collection_descriptors: List[CollectionDescriptor],
+        collection_descriptors: list[CollectionDescriptor],
         collection_name: str,
-        requested_indexing_policy: Optional[Dict[str, Any]],
-        default_indexing_policy: Optional[Dict[str, Any]],
+        requested_indexing_policy: dict[str, Any] | None,
+        default_indexing_policy: dict[str, Any] | None,
     ) -> bool:
         """
         This is a validation helper, to be called when the collection-creation

--- a/libs/astradb/langchain_astradb/utils/mmr.py
+++ b/libs/astradb/langchain_astradb/utils/mmr.py
@@ -7,6 +7,7 @@ are duplicated in this utility respectively from modules:
     - "libs/community/langchain_community/vectorstores/utils.py"
     - "libs/community/langchain_community/utils/math.py"
 """
+from __future__ import annotations
 
 import logging
 from typing import List, Union
@@ -58,7 +59,7 @@ def maximal_marginal_relevance(
     embedding_list: list,
     lambda_mult: float = 0.5,
     k: int = 4,
-) -> List[int]:
+) -> list[int]:
     """Calculate maximal marginal relevance."""
     if min(k, len(embedding_list)) <= 0:
         return []

--- a/libs/astradb/langchain_astradb/vectorstores.py
+++ b/libs/astradb/langchain_astradb/vectorstores.py
@@ -11,13 +11,7 @@ from typing import (
     Callable,
     Dict,
     Iterable,
-    List,
-    Optional,
-    Set,
-    Tuple,
-    Type,
     TypeVar,
-    Union,
 )
 
 import numpy as np
@@ -54,8 +48,8 @@ DocDict = Dict[str, Any]  # dicts expressing entries to insert
 DEFAULT_INDEXING_OPTIONS = {"allow": ["metadata"]}
 
 
-def _unique_list(lst: List[T], key: Callable[[T], U]) -> List[T]:
-    visited_keys: Set[U] = set()
+def _unique_list(lst: list[T], key: Callable[[T], U]) -> list[T]:
+    visited_keys: set[U] = set()
     new_lst = []
     for item in lst:
         item_key = key(item)
@@ -198,7 +192,7 @@ class AstraDBVectorStore(VectorStore):
     """  # noqa: E501
 
     @staticmethod
-    def _filter_to_metadata(filter_dict: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+    def _filter_to_metadata(filter_dict: dict[str, Any] | None) -> dict[str, Any]:
         if filter_dict is None:
             return {}
         else:
@@ -219,10 +213,10 @@ class AstraDBVectorStore(VectorStore):
 
     @staticmethod
     def _normalize_metadata_indexing_policy(
-        metadata_indexing_include: Optional[Iterable[str]],
-        metadata_indexing_exclude: Optional[Iterable[str]],
-        collection_indexing_policy: Optional[Dict[str, Any]],
-    ) -> Dict[str, Any]:
+        metadata_indexing_include: Iterable[str] | None,
+        metadata_indexing_exclude: Iterable[str] | None,
+        collection_indexing_policy: dict[str, Any] | None,
+    ) -> dict[str, Any]:
         """
         Validate the constructor indexing parameters and normalize them
         into a ready-to-use dict for the 'options' when creating a collection.
@@ -265,29 +259,25 @@ class AstraDBVectorStore(VectorStore):
         self,
         *,
         collection_name: str,
-        embedding: Optional[Embeddings] = None,
-        token: Optional[Union[str, TokenProvider]] = None,
-        api_endpoint: Optional[str] = None,
-        environment: Optional[str] = None,
-        astra_db_client: Optional[AstraDBClient] = None,
-        async_astra_db_client: Optional[AsyncAstraDBClient] = None,
-        namespace: Optional[str] = None,
-        metric: Optional[str] = None,
-        batch_size: Optional[int] = None,
-        bulk_insert_batch_concurrency: Optional[int] = None,
-        bulk_insert_overwrite_concurrency: Optional[int] = None,
-        bulk_delete_concurrency: Optional[int] = None,
+        embedding: Embeddings | None = None,
+        token: str | TokenProvider | None = None,
+        api_endpoint: str | None = None,
+        environment: str | None = None,
+        astra_db_client: AstraDBClient | None = None,
+        async_astra_db_client: AsyncAstraDBClient | None = None,
+        namespace: str | None = None,
+        metric: str | None = None,
+        batch_size: int | None = None,
+        bulk_insert_batch_concurrency: int | None = None,
+        bulk_insert_overwrite_concurrency: int | None = None,
+        bulk_delete_concurrency: int | None = None,
         setup_mode: SetupMode = SetupMode.SYNC,
         pre_delete_collection: bool = False,
-        metadata_indexing_include: Optional[Iterable[str]] = None,
-        metadata_indexing_exclude: Optional[Iterable[str]] = None,
-        collection_indexing_policy: Optional[Dict[str, Any]] = None,
-        collection_vector_service_options: Optional[
-            CollectionVectorServiceOptions
-        ] = None,
-        collection_embedding_api_key: Optional[
-            Union[str, EmbeddingHeadersProvider]
-        ] = None,
+        metadata_indexing_include: Iterable[str] | None = None,
+        metadata_indexing_exclude: Iterable[str] | None = None,
+        collection_indexing_policy: dict[str, Any] | None = None,
+        collection_vector_service_options: CollectionVectorServiceOptions | None = None,
+        collection_embedding_api_key: str | EmbeddingHeadersProvider | None = None,
     ) -> None:
         """Wrapper around DataStax Astra DB for vector-store workloads.
 
@@ -402,7 +392,7 @@ class AstraDBVectorStore(VectorStore):
                 " `collection_vector_service_options` is also passed."
             )
 
-        self.embedding_dimension: Optional[int] = None
+        self.embedding_dimension: int | None = None
         self.embedding = embedding
         self.collection_name = collection_name
         self.token = token
@@ -412,7 +402,7 @@ class AstraDBVectorStore(VectorStore):
         self.collection_vector_service_options = collection_vector_service_options
         self.collection_embedding_api_key = collection_embedding_api_key
         # Concurrency settings
-        self.batch_size: Optional[int] = batch_size or DEFAULT_DOCUMENT_CHUNK_SIZE
+        self.batch_size: int | None = batch_size or DEFAULT_DOCUMENT_CHUNK_SIZE
         self.bulk_insert_batch_concurrency: int = (
             bulk_insert_batch_concurrency or MAX_CONCURRENT_DOCUMENT_INSERTIONS
         )
@@ -424,7 +414,7 @@ class AstraDBVectorStore(VectorStore):
         )
         # "vector-related" settings
         self.metric = metric
-        embedding_dimension_m: Union[int, Awaitable[int], None] = None
+        embedding_dimension_m: int | Awaitable[int] | None = None
         if self.embedding is not None:
             if setup_mode == SetupMode.ASYNC:
                 embedding_dimension_m = self._aget_embedding_dimension()
@@ -432,7 +422,7 @@ class AstraDBVectorStore(VectorStore):
                 embedding_dimension_m = self._get_embedding_dimension()
 
         # indexing policy setting
-        self.indexing_policy: Dict[str, Any] = self._normalize_metadata_indexing_policy(
+        self.indexing_policy: dict[str, Any] = self._normalize_metadata_indexing_policy(
             metadata_indexing_include=metadata_indexing_include,
             metadata_indexing_exclude=metadata_indexing_exclude,
             collection_indexing_policy=collection_indexing_policy,
@@ -475,7 +465,7 @@ class AstraDBVectorStore(VectorStore):
         return self.embedding_dimension
 
     @property
-    def embeddings(self) -> Optional[Embeddings]:
+    def embeddings(self) -> Embeddings | None:
         """
         Accesses the supplied embeddings object. If using server-side embeddings,
         this will return None.
@@ -537,10 +527,10 @@ class AstraDBVectorStore(VectorStore):
 
     def delete(
         self,
-        ids: Optional[List[str]] = None,
-        concurrency: Optional[int] = None,
+        ids: list[str] | None = None,
+        concurrency: int | None = None,
         **kwargs: Any,
-    ) -> Optional[bool]:
+    ) -> bool | None:
         """Delete by vector ids.
 
         Args:
@@ -574,10 +564,10 @@ class AstraDBVectorStore(VectorStore):
 
     async def adelete(
         self,
-        ids: Optional[List[str]] = None,
-        concurrency: Optional[int] = None,
+        ids: list[str] | None = None,
+        concurrency: int | None = None,
         **kwargs: Any,
-    ) -> Optional[bool]:
+    ) -> bool | None:
         """Delete by vector ids.
 
         Args:
@@ -628,10 +618,10 @@ class AstraDBVectorStore(VectorStore):
     @staticmethod
     def _get_documents_to_insert(
         texts: Iterable[str],
-        embedding_vectors: List[List[float]],
-        metadatas: Optional[List[dict]] = None,
-        ids: Optional[List[str]] = None,
-    ) -> List[DocDict]:
+        embedding_vectors: list[list[float]],
+        metadatas: list[dict] | None = None,
+        ids: list[str] | None = None,
+    ) -> list[DocDict]:
         if ids is None:
             ids = [uuid.uuid4().hex for _ in texts]
         if metadatas is None:
@@ -661,9 +651,9 @@ class AstraDBVectorStore(VectorStore):
     @staticmethod
     def _get_vectorize_documents_to_insert(
         texts: Iterable[str],
-        metadatas: Optional[List[dict]] = None,
-        ids: Optional[List[str]] = None,
-    ) -> List[DocDict]:
+        metadatas: list[dict] | None = None,
+        ids: list[str] | None = None,
+    ) -> list[DocDict]:
         if ids is None:
             ids = [uuid.uuid4().hex for _ in texts]
         if metadatas is None:
@@ -690,8 +680,8 @@ class AstraDBVectorStore(VectorStore):
 
     @staticmethod
     def _get_missing_from_batch(
-        document_batch: List[DocDict], insert_result: Dict[str, Any]
-    ) -> Tuple[List[str], List[DocDict]]:
+        document_batch: list[DocDict], insert_result: dict[str, Any]
+    ) -> tuple[list[str], list[DocDict]]:
         if "status" not in insert_result:
             raise ValueError(
                 f"API Exception while running bulk insertion: {str(insert_result)}"
@@ -722,14 +712,14 @@ class AstraDBVectorStore(VectorStore):
     def add_texts(
         self,
         texts: Iterable[str],
-        metadatas: Optional[List[dict]] = None,
-        ids: Optional[List[str]] = None,
+        metadatas: list[dict] | None = None,
+        ids: list[str] | None = None,
         *,
-        batch_size: Optional[int] = None,
-        batch_concurrency: Optional[int] = None,
-        overwrite_concurrency: Optional[int] = None,
+        batch_size: int | None = None,
+        batch_concurrency: int | None = None,
+        overwrite_concurrency: int | None = None,
         **kwargs: Any,
-    ) -> List[str]:
+    ) -> list[str]:
         """Run texts through the embeddings and add them to the vectorstore.
 
         If passing explicit ids, those entries whose id is in the store already
@@ -780,8 +770,8 @@ class AstraDBVectorStore(VectorStore):
             )
 
         # perform an AstraPy insert_many, catching exceptions for overwriting docs
-        ids_to_replace: List[int]
-        inserted_ids: List[str] = []
+        ids_to_replace: list[int]
+        inserted_ids: list[str] = []
         try:
             insert_many_result = self.astra_env.collection.insert_many(
                 documents_to_insert,
@@ -816,8 +806,8 @@ class AstraDBVectorStore(VectorStore):
             ) as executor:
 
                 def _replace_document(
-                    document: Dict[str, Any],
-                ) -> Tuple[UpdateResult, str]:
+                    document: dict[str, Any],
+                ) -> tuple[UpdateResult, str]:
                     return self.astra_env.collection.replace_one(
                         {"_id": document["_id"]},
                         document,
@@ -843,14 +833,14 @@ class AstraDBVectorStore(VectorStore):
     async def aadd_texts(
         self,
         texts: Iterable[str],
-        metadatas: Optional[List[dict]] = None,
-        ids: Optional[List[str]] = None,
+        metadatas: list[dict] | None = None,
+        ids: list[str] | None = None,
         *,
-        batch_size: Optional[int] = None,
-        batch_concurrency: Optional[int] = None,
-        overwrite_concurrency: Optional[int] = None,
+        batch_size: int | None = None,
+        batch_concurrency: int | None = None,
+        overwrite_concurrency: int | None = None,
         **kwargs: Any,
-    ) -> List[str]:
+    ) -> list[str]:
         """Run texts through the embeddings and add them to the vectorstore.
 
         If passing explicit ids, those entries whose id is in the store already
@@ -901,8 +891,8 @@ class AstraDBVectorStore(VectorStore):
             )
 
         # perform an AstraPy insert_many, catching exceptions for overwriting docs
-        ids_to_replace: List[int]
-        inserted_ids: List[str] = []
+        ids_to_replace: list[int]
+        inserted_ids: list[str] = []
         try:
             insert_many_result = await self.astra_env.async_collection.insert_many(
                 documents_to_insert,
@@ -936,8 +926,8 @@ class AstraDBVectorStore(VectorStore):
             _async_collection = self.astra_env.async_collection
 
             async def _replace_document(
-                document: Dict[str, Any],
-            ) -> Tuple[UpdateResult, str]:
+                document: dict[str, Any],
+            ) -> tuple[UpdateResult, str]:
                 async with sem:
                     return await _async_collection.replace_one(
                         {"_id": document["_id"]},
@@ -964,10 +954,10 @@ class AstraDBVectorStore(VectorStore):
 
     def similarity_search_with_score_id_by_vector(
         self,
-        embedding: List[float],
+        embedding: list[float],
         k: int = 4,
-        filter: Optional[Dict[str, Any]] = None,
-    ) -> List[Tuple[Document, float, str]]:
+        filter: dict[str, Any] | None = None,
+    ) -> list[tuple[Document, float, str]]:
         """Return docs most similar to embedding vector with score and id.
 
         Args:
@@ -1009,10 +999,10 @@ class AstraDBVectorStore(VectorStore):
 
     async def asimilarity_search_with_score_id_by_vector(
         self,
-        embedding: List[float],
+        embedding: list[float],
         k: int = 4,
-        filter: Optional[Dict[str, Any]] = None,
-    ) -> List[Tuple[Document, float, str]]:
+        filter: dict[str, Any] | None = None,
+    ) -> list[tuple[Document, float, str]]:
         """Return docs most similar to embedding vector with score and id.
 
         Args:
@@ -1052,8 +1042,8 @@ class AstraDBVectorStore(VectorStore):
         self,
         query: str,
         k: int = 4,
-        filter: Optional[Dict[str, Any]] = None,
-    ) -> List[Tuple[Document, float, str]]:
+        filter: dict[str, Any] | None = None,
+    ) -> list[tuple[Document, float, str]]:
         """Return docs most similar to the query with score and id using $vectorize.
 
         This is only available when using server-side embeddings.
@@ -1092,8 +1082,8 @@ class AstraDBVectorStore(VectorStore):
         self,
         query: str,
         k: int = 4,
-        filter: Optional[Dict[str, Any]] = None,
-    ) -> List[Tuple[Document, float, str]]:
+        filter: dict[str, Any] | None = None,
+    ) -> list[tuple[Document, float, str]]:
         """Return docs most similar to the query with score and id using $vectorize.
 
         This is only available when using server-side embeddings.
@@ -1128,8 +1118,8 @@ class AstraDBVectorStore(VectorStore):
         self,
         query: str,
         k: int = 4,
-        filter: Optional[Dict[str, Any]] = None,
-    ) -> List[Tuple[Document, float, str]]:
+        filter: dict[str, Any] | None = None,
+    ) -> list[tuple[Document, float, str]]:
         """Return docs most similar to the query with score and id.
 
         Args:
@@ -1160,8 +1150,8 @@ class AstraDBVectorStore(VectorStore):
         self,
         query: str,
         k: int = 4,
-        filter: Optional[Dict[str, Any]] = None,
-    ) -> List[Tuple[Document, float, str]]:
+        filter: dict[str, Any] | None = None,
+    ) -> list[tuple[Document, float, str]]:
         """Return docs most similar to the query with score and id.
 
         Args:
@@ -1189,10 +1179,10 @@ class AstraDBVectorStore(VectorStore):
 
     def similarity_search_with_score_by_vector(
         self,
-        embedding: List[float],
+        embedding: list[float],
         k: int = 4,
-        filter: Optional[Dict[str, Any]] = None,
-    ) -> List[Tuple[Document, float]]:
+        filter: dict[str, Any] | None = None,
+    ) -> list[tuple[Document, float]]:
         """Return docs most similar to embedding vector with score.
 
         Args:
@@ -1214,10 +1204,10 @@ class AstraDBVectorStore(VectorStore):
 
     async def asimilarity_search_with_score_by_vector(
         self,
-        embedding: List[float],
+        embedding: list[float],
         k: int = 4,
-        filter: Optional[Dict[str, Any]] = None,
-    ) -> List[Tuple[Document, float]]:
+        filter: dict[str, Any] | None = None,
+    ) -> list[tuple[Document, float]]:
         """Return docs most similar to embedding vector with score.
 
         Args:
@@ -1245,9 +1235,9 @@ class AstraDBVectorStore(VectorStore):
         self,
         query: str,
         k: int = 4,
-        filter: Optional[Dict[str, Any]] = None,
+        filter: dict[str, Any] | None = None,
         **kwargs: Any,
-    ) -> List[Document]:
+    ) -> list[Document]:
         """Return docs most similar to query.
 
         Args:
@@ -1280,9 +1270,9 @@ class AstraDBVectorStore(VectorStore):
         self,
         query: str,
         k: int = 4,
-        filter: Optional[Dict[str, Any]] = None,
+        filter: dict[str, Any] | None = None,
         **kwargs: Any,
-    ) -> List[Document]:
+    ) -> list[Document]:
         """Return docs most similar to query.
 
         Args:
@@ -1317,11 +1307,11 @@ class AstraDBVectorStore(VectorStore):
 
     def similarity_search_by_vector(
         self,
-        embedding: List[float],
+        embedding: list[float],
         k: int = 4,
-        filter: Optional[Dict[str, Any]] = None,
+        filter: dict[str, Any] | None = None,
         **kwargs: Any,
-    ) -> List[Document]:
+    ) -> list[Document]:
         """Return docs most similar to embedding vector.
 
         Args:
@@ -1343,11 +1333,11 @@ class AstraDBVectorStore(VectorStore):
 
     async def asimilarity_search_by_vector(
         self,
-        embedding: List[float],
+        embedding: list[float],
         k: int = 4,
-        filter: Optional[Dict[str, Any]] = None,
+        filter: dict[str, Any] | None = None,
         **kwargs: Any,
-    ) -> List[Document]:
+    ) -> list[Document]:
         """Return docs most similar to embedding vector.
 
         Args:
@@ -1371,8 +1361,8 @@ class AstraDBVectorStore(VectorStore):
         self,
         query: str,
         k: int = 4,
-        filter: Optional[Dict[str, Any]] = None,
-    ) -> List[Tuple[Document, float]]:
+        filter: dict[str, Any] | None = None,
+    ) -> list[tuple[Document, float]]:
         """Return docs most similar to query with score.
 
         Args:
@@ -1409,8 +1399,8 @@ class AstraDBVectorStore(VectorStore):
         self,
         query: str,
         k: int = 4,
-        filter: Optional[Dict[str, Any]] = None,
-    ) -> List[Tuple[Document, float]]:
+        filter: dict[str, Any] | None = None,
+    ) -> list[tuple[Document, float]]:
         """Return docs most similar to query with score.
 
         Args:
@@ -1445,13 +1435,13 @@ class AstraDBVectorStore(VectorStore):
 
     def _run_mmr_query_by_sort(
         self,
-        sort: Dict[str, Any],
+        sort: dict[str, Any],
         k: int,
         fetch_k: int,
         lambda_mult: float,
-        metadata_parameter: Dict[str, Any],
+        metadata_parameter: dict[str, Any],
         **kwargs: Any,
-    ) -> List[Document]:
+    ) -> list[Document]:
         prefetch_cursor = self.astra_env.collection.find(
             filter=metadata_parameter,
             projection={
@@ -1478,13 +1468,13 @@ class AstraDBVectorStore(VectorStore):
 
     async def _arun_mmr_query_by_sort(
         self,
-        sort: Dict[str, Any],
+        sort: dict[str, Any],
         k: int,
         fetch_k: int,
         lambda_mult: float,
-        metadata_parameter: Dict[str, Any],
+        metadata_parameter: dict[str, Any],
         **kwargs: Any,
-    ) -> List[Document]:
+    ) -> list[Document]:
         prefetch_cursor = self.astra_env.async_collection.find(
             filter=metadata_parameter,
             projection={
@@ -1511,12 +1501,12 @@ class AstraDBVectorStore(VectorStore):
 
     @staticmethod
     def _get_mmr_hits(
-        embedding: List[float],
+        embedding: list[float],
         k: int,
         lambda_mult: float,
-        prefetch_hits: List[DocDict],
+        prefetch_hits: list[DocDict],
         content_field: str,
-    ) -> List[Document]:
+    ) -> list[Document]:
         mmr_chosen_indices = maximal_marginal_relevance(
             np.array(embedding, dtype=np.float32),
             [prefetch_hit["$vector"] for prefetch_hit in prefetch_hits],
@@ -1538,13 +1528,13 @@ class AstraDBVectorStore(VectorStore):
 
     def max_marginal_relevance_search_by_vector(
         self,
-        embedding: List[float],
+        embedding: list[float],
         k: int = 4,
         fetch_k: int = 20,
         lambda_mult: float = 0.5,
-        filter: Optional[Dict[str, Any]] = None,
+        filter: dict[str, Any] | None = None,
         **kwargs: Any,
-    ) -> List[Document]:
+    ) -> list[Document]:
         """Return docs selected using the maximal marginal relevance.
 
         Maximal marginal relevance optimizes for similarity to query AND diversity
@@ -1575,13 +1565,13 @@ class AstraDBVectorStore(VectorStore):
 
     async def amax_marginal_relevance_search_by_vector(
         self,
-        embedding: List[float],
+        embedding: list[float],
         k: int = 4,
         fetch_k: int = 20,
         lambda_mult: float = 0.5,
-        filter: Optional[Dict[str, Any]] = None,
+        filter: dict[str, Any] | None = None,
         **kwargs: Any,
-    ) -> List[Document]:
+    ) -> list[Document]:
         """Return docs selected using the maximal marginal relevance.
 
         Maximal marginal relevance optimizes for similarity to query AND diversity
@@ -1616,9 +1606,9 @@ class AstraDBVectorStore(VectorStore):
         k: int = 4,
         fetch_k: int = 20,
         lambda_mult: float = 0.5,
-        filter: Optional[Dict[str, Any]] = None,
+        filter: dict[str, Any] | None = None,
         **kwargs: Any,
-    ) -> List[Document]:
+    ) -> list[Document]:
         """Return docs selected using the maximal marginal relevance.
 
         Maximal marginal relevance optimizes for similarity to query AND diversity
@@ -1665,9 +1655,9 @@ class AstraDBVectorStore(VectorStore):
         k: int = 4,
         fetch_k: int = 20,
         lambda_mult: float = 0.5,
-        filter: Optional[Dict[str, Any]] = None,
+        filter: dict[str, Any] | None = None,
         **kwargs: Any,
-    ) -> List[Document]:
+    ) -> list[Document]:
         """Return docs selected using the maximal marginal relevance.
 
         Maximal marginal relevance optimizes for similarity to query AND diversity
@@ -1710,7 +1700,7 @@ class AstraDBVectorStore(VectorStore):
 
     @classmethod
     def _from_kwargs(
-        cls: Type[AstraDBVectorStore],
+        cls: type[AstraDBVectorStore],
         **kwargs: Any,
     ) -> AstraDBVectorStore:
         _args = inspect.getfullargspec(AstraDBVectorStore.__init__).args
@@ -1734,11 +1724,11 @@ class AstraDBVectorStore(VectorStore):
 
     @classmethod
     def from_texts(
-        cls: Type[AstraDBVectorStore],
-        texts: List[str],
-        embedding: Optional[Embeddings] = None,
-        metadatas: Optional[List[dict]] = None,
-        ids: Optional[List[str]] = None,
+        cls: type[AstraDBVectorStore],
+        texts: list[str],
+        embedding: Embeddings | None = None,
+        metadatas: list[dict] | None = None,
+        ids: list[str] | None = None,
         **kwargs: Any,
     ) -> AstraDBVectorStore:
         """Create an Astra DB vectorstore from raw texts.
@@ -1777,11 +1767,11 @@ class AstraDBVectorStore(VectorStore):
 
     @classmethod
     async def afrom_texts(
-        cls: Type[AstraDBVectorStore],
-        texts: List[str],
-        embedding: Optional[Embeddings] = None,
-        metadatas: Optional[List[dict]] = None,
-        ids: Optional[List[str]] = None,
+        cls: type[AstraDBVectorStore],
+        texts: list[str],
+        embedding: Embeddings | None = None,
+        metadatas: list[dict] | None = None,
+        ids: list[str] | None = None,
         **kwargs: Any,
     ) -> AstraDBVectorStore:
         """Create an Astra DB vectorstore from raw texts.
@@ -1819,9 +1809,9 @@ class AstraDBVectorStore(VectorStore):
 
     @classmethod
     def from_documents(
-        cls: Type[AstraDBVectorStore],
-        documents: List[Document],
-        embedding: Optional[Embeddings] = None,
+        cls: type[AstraDBVectorStore],
+        documents: list[Document],
+        embedding: Embeddings | None = None,
         **kwargs: Any,
     ) -> AstraDBVectorStore:
         """Create an Astra DB vectorstore from a document list.
@@ -1845,9 +1835,9 @@ class AstraDBVectorStore(VectorStore):
 
     @classmethod
     async def afrom_documents(
-        cls: Type[AstraDBVectorStore],
-        documents: List[Document],
-        embedding: Optional[Embeddings] = None,
+        cls: type[AstraDBVectorStore],
+        documents: list[Document],
+        embedding: Embeddings | None = None,
         **kwargs: Any,
     ) -> AstraDBVectorStore:
         """Create an Astra DB vectorstore from a document list.

--- a/libs/astradb/tests/conftest.py
+++ b/libs/astradb/tests/conftest.py
@@ -3,8 +3,9 @@ General-purpose testing tools, such as:
     - Ad-hoc embedding classes
 """
 
+from __future__ import annotations
+
 import json
-from typing import List
 
 from langchain_core.embeddings import Embeddings
 
@@ -18,13 +19,13 @@ class SomeEmbeddings(Embeddings):
     def __init__(self, dimension: int) -> None:
         self.dimension = dimension
 
-    def embed_documents(self, texts: List[str]) -> List[List[float]]:
+    def embed_documents(self, texts: list[str]) -> list[list[float]]:
         return [self.embed_query(txt) for txt in texts]
 
-    async def aembed_documents(self, texts: List[str]) -> List[List[float]]:
+    async def aembed_documents(self, texts: list[str]) -> list[list[float]]:
         return self.embed_documents(texts)
 
-    def embed_query(self, text: str) -> List[float]:
+    def embed_query(self, text: str) -> list[float]:
         unnormed0 = [ord(c) for c in text[: self.dimension]]
         unnormed = (unnormed0 + [1] + [0] * (self.dimension - 1 - len(unnormed0)))[
             : self.dimension
@@ -33,7 +34,7 @@ class SomeEmbeddings(Embeddings):
         normed = [x / norm for x in unnormed]
         return normed
 
-    async def aembed_query(self, text: str) -> List[float]:
+    async def aembed_query(self, text: str) -> list[float]:
         return self.embed_query(text)
 
 
@@ -46,13 +47,13 @@ class ParserEmbeddings(Embeddings):
     def __init__(self, dimension: int) -> None:
         self.dimension = dimension
 
-    def embed_documents(self, texts: List[str]) -> List[List[float]]:
+    def embed_documents(self, texts: list[str]) -> list[list[float]]:
         return [self.embed_query(txt) for txt in texts]
 
-    async def aembed_documents(self, texts: List[str]) -> List[List[float]]:
+    async def aembed_documents(self, texts: list[str]) -> list[list[float]]:
         return self.embed_documents(texts)
 
-    def embed_query(self, text: str) -> List[float]:
+    def embed_query(self, text: str) -> list[float]:
         try:
             vals = json.loads(text)
             assert len(vals) == self.dimension
@@ -61,5 +62,5 @@ class ParserEmbeddings(Embeddings):
             print(f'[ParserEmbeddings] Returning a moot vector for "{text}"')
             return [0.0] * self.dimension
 
-    async def aembed_query(self, text: str) -> List[float]:
+    async def aembed_query(self, text: str) -> list[float]:
         return self.embed_query(text)

--- a/libs/astradb/tests/integration_tests/conftest.py
+++ b/libs/astradb/tests/integration_tests/conftest.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 import os
-from typing import Optional, TypedDict
+from typing import TypedDict
 
 import pytest
 from astrapy import Database
@@ -33,8 +35,8 @@ def _has_env_vars() -> bool:
 class AstraDBCredentials(TypedDict):
     token: str
     api_endpoint: str
-    namespace: Optional[str]
-    environment: Optional[str]
+    namespace: str | None
+    environment: str | None
 
 
 @pytest.fixture(scope="session")

--- a/libs/astradb/tests/integration_tests/test_caches.py
+++ b/libs/astradb/tests/integration_tests/test_caches.py
@@ -11,8 +11,10 @@ Required to run this test:
         export ASTRA_DB_KEYSPACE="my_keyspace"
 """
 
+from __future__ import annotations
+
 import os
-from typing import Any, AsyncIterator, Dict, Iterator, List, Mapping, Optional, cast
+from typing import Any, AsyncIterator, Iterator, Mapping, Optional, cast
 
 import pytest
 from astrapy.db import AstraDB
@@ -33,22 +35,22 @@ from .conftest import AstraDBCredentials, _has_env_vars
 class FakeEmbeddings(Embeddings):
     """Fake embeddings functionality for testing."""
 
-    def embed_documents(self, texts: List[str]) -> List[List[float]]:
+    def embed_documents(self, texts: list[str]) -> list[list[float]]:
         """Return simple embeddings.
         Embeddings encode each text as its index."""
         return [[float(1.0)] * 9 + [float(i)] for i in range(len(texts))]
 
-    async def aembed_documents(self, texts: List[str]) -> List[List[float]]:
+    async def aembed_documents(self, texts: list[str]) -> list[list[float]]:
         return self.embed_documents(texts)
 
-    def embed_query(self, text: str) -> List[float]:
+    def embed_query(self, text: str) -> list[float]:
         """Return constant query embeddings.
         Embeddings are identical to embed_documents(texts)[0].
         Distance to each text will be that text's index,
         as it was passed to embed_documents."""
         return [float(1.0)] * 9 + [float(0.0)]
 
-    async def aembed_query(self, text: str) -> List[float]:
+    async def aembed_query(self, text: str) -> list[float]:
         return self.embed_query(text)
 
 
@@ -61,8 +63,8 @@ class FakeLLM(LLM):
 
     @validator("queries", always=True)
     def check_queries_required(
-        cls, queries: Optional[Mapping], values: Mapping[str, Any]
-    ) -> Optional[Mapping]:
+        cls, queries: Mapping | None, values: Mapping[str, Any]
+    ) -> Mapping | None:
         if values.get("sequential_response") and not queries:
             raise ValueError(
                 "queries is required when sequential_response is set to True"
@@ -81,8 +83,8 @@ class FakeLLM(LLM):
     def _call(
         self,
         prompt: str,
-        stop: Optional[List[str]] = None,
-        run_manager: Optional[CallbackManagerForLLMRun] = None,
+        stop: list[str] | None = None,
+        run_manager: CallbackManagerForLLMRun | None = None,
         **kwargs: Any,
     ) -> str:
         if self.sequential_responses:
@@ -95,7 +97,7 @@ class FakeLLM(LLM):
             return "bar"
 
     @property
-    def _identifying_params(self) -> Dict[str, Any]:
+    def _identifying_params(self) -> dict[str, Any]:
         return {}
 
     @property

--- a/libs/astradb/tests/integration_tests/test_storage.py
+++ b/libs/astradb/tests/integration_tests/test_storage.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 import os
-from typing import Dict, Optional
 
 import pytest
 from astrapy import Database
@@ -15,7 +14,7 @@ from .conftest import _has_env_vars
 
 
 def init_store(
-    astra_db_credentials: Dict[str, Optional[str]],
+    astra_db_credentials: dict[str, str | None],
     collection_name: str,
 ) -> AstraDBStore:
     store = AstraDBStore(
@@ -30,7 +29,7 @@ def init_store(
 
 
 def init_bytestore(
-    astra_db_credentials: Dict[str, Optional[str]],
+    astra_db_credentials: dict[str, str | None],
     collection_name: str,
 ) -> AstraDBByteStore:
     store = AstraDBByteStore(
@@ -45,7 +44,7 @@ def init_bytestore(
 
 
 async def init_async_store(
-    astra_db_credentials: Dict[str, Optional[str]], collection_name: str
+    astra_db_credentials: dict[str, str | None], collection_name: str
 ) -> AstraDBStore:
     store = AstraDBStore(
         collection_name=collection_name,
@@ -63,7 +62,7 @@ async def init_async_store(
 class TestAstraDBStore:
     def test_mget(
         self,
-        astra_db_credentials: Dict[str, Optional[str]],
+        astra_db_credentials: dict[str, str | None],
     ) -> None:
         """Test AstraDBStore mget method."""
         collection_name = "lc_test_store_mget"
@@ -75,7 +74,7 @@ class TestAstraDBStore:
 
     async def test_amget(
         self,
-        astra_db_credentials: Dict[str, Optional[str]],
+        astra_db_credentials: dict[str, str | None],
     ) -> None:
         """Test AstraDBStore amget method."""
         collection_name = "lc_test_store_mget"
@@ -87,7 +86,7 @@ class TestAstraDBStore:
 
     def test_mset(
         self,
-        astra_db_credentials: Dict[str, Optional[str]],
+        astra_db_credentials: dict[str, str | None],
     ) -> None:
         """Test that multiple keys can be set with AstraDBStore."""
         collection_name = "lc_test_store_mset"
@@ -102,7 +101,7 @@ class TestAstraDBStore:
 
     async def test_amset(
         self,
-        astra_db_credentials: Dict[str, Optional[str]],
+        astra_db_credentials: dict[str, str | None],
     ) -> None:
         """Test that multiple keys can be set with AstraDBStore."""
         collection_name = "lc_test_store_mset"
@@ -117,7 +116,7 @@ class TestAstraDBStore:
 
     def test_store_massive_mset_with_replace(
         self,
-        astra_db_credentials: Dict[str, Optional[str]],
+        astra_db_credentials: dict[str, str | None],
     ) -> None:
         """Testing the insert-many-and-replace-some patterns thoroughly."""
         FULL_SIZE = 300
@@ -181,7 +180,7 @@ class TestAstraDBStore:
 
     async def test_store_massive_amset_with_replace(
         self,
-        astra_db_credentials: Dict[str, Optional[str]],
+        astra_db_credentials: dict[str, str | None],
     ) -> None:
         """Testing the insert-many-and-replace-some patterns thoroughly."""
         FULL_SIZE = 300
@@ -246,7 +245,7 @@ class TestAstraDBStore:
 
     def test_mdelete(
         self,
-        astra_db_credentials: Dict[str, Optional[str]],
+        astra_db_credentials: dict[str, str | None],
     ) -> None:
         """Test that deletion works as expected."""
         collection_name = "lc_test_store_mdelete"
@@ -260,7 +259,7 @@ class TestAstraDBStore:
 
     async def test_amdelete(
         self,
-        astra_db_credentials: Dict[str, Optional[str]],
+        astra_db_credentials: dict[str, str | None],
     ) -> None:
         """Test that deletion works as expected."""
         collection_name = "lc_test_store_mdelete"
@@ -274,7 +273,7 @@ class TestAstraDBStore:
 
     def test_yield_keys(
         self,
-        astra_db_credentials: Dict[str, Optional[str]],
+        astra_db_credentials: dict[str, str | None],
     ) -> None:
         collection_name = "lc_test_store_yield_keys"
         try:
@@ -287,7 +286,7 @@ class TestAstraDBStore:
 
     async def test_ayield_keys(
         self,
-        astra_db_credentials: Dict[str, Optional[str]],
+        astra_db_credentials: dict[str, str | None],
     ) -> None:
         collection_name = "lc_test_store_yield_keys"
         try:
@@ -303,7 +302,7 @@ class TestAstraDBStore:
 
     def test_bytestore_mget(
         self,
-        astra_db_credentials: Dict[str, Optional[str]],
+        astra_db_credentials: dict[str, str | None],
     ) -> None:
         """Test AstraDBByteStore mget method."""
         collection_name = "lc_test_bytestore_mget"
@@ -315,7 +314,7 @@ class TestAstraDBStore:
 
     def test_bytestore_mset(
         self,
-        astra_db_credentials: Dict[str, Optional[str]],
+        astra_db_credentials: dict[str, str | None],
     ) -> None:
         """Test that multiple keys can be set with AstraDBByteStore."""
         collection_name = "lc_test_bytestore_mset"
@@ -330,7 +329,7 @@ class TestAstraDBStore:
 
     def test_indexing_detection(
         self,
-        astra_db_credentials: Dict[str, Optional[str]],
+        astra_db_credentials: dict[str, str | None],
         database: Database,
     ) -> None:
         """Test the behaviour against preexisting legacy collections."""
@@ -384,7 +383,7 @@ class TestAstraDBStore:
     )
     def test_store_coreclients_init_sync(
         self,
-        astra_db_credentials: Dict[str, Optional[str]],
+        astra_db_credentials: dict[str, str | None],
         core_astra_db: AstraDB,
     ) -> None:
         """A deprecation warning from passing a (core) AstraDB, but it works."""
@@ -414,7 +413,7 @@ class TestAstraDBStore:
     )
     async def test_store_coreclients_init_async(
         self,
-        astra_db_credentials: Dict[str, Optional[str]],
+        astra_db_credentials: dict[str, str | None],
         core_astra_db: AstraDB,
     ) -> None:
         """A deprecation warning from passing a (core) AstraDB, but it works."""

--- a/libs/astradb/tests/integration_tests/test_vectorstores.py
+++ b/libs/astradb/tests/integration_tests/test_vectorstores.py
@@ -19,11 +19,13 @@ Required to run this test:
         export ASTRA_DB_SKIP_COLLECTION_DELETIONS="0" ("1" = no deletions, default)
 """
 
+from __future__ import annotations
+
 import json
 import math
 import os
 import warnings
-from typing import Dict, Iterable, Optional
+from typing import Iterable
 
 import pytest
 from astrapy import Database
@@ -1392,7 +1394,7 @@ class TestAstraDBVectorStore:
 
     def test_astradb_vectorstore_indexing_sync(
         self,
-        astra_db_credentials: Dict[str, Optional[str]],
+        astra_db_credentials: dict[str, str | None],
         database: Database,
     ) -> None:
         """
@@ -1508,7 +1510,7 @@ class TestAstraDBVectorStore:
 
     async def test_astradb_vectorstore_indexing_async(
         self,
-        astra_db_credentials: Dict[str, Optional[str]],
+        astra_db_credentials: dict[str, str | None],
         database: Database,
     ) -> None:
         """
@@ -1646,7 +1648,7 @@ class TestAstraDBVectorStore:
     )
     def test_astradb_vectorstore_coreclients_init_sync(
         self,
-        astra_db_credentials: Dict[str, Optional[str]],
+        astra_db_credentials: dict[str, str | None],
         core_astra_db: AstraDB,
     ) -> None:
         """A deprecation warning from passing a (core) AstraDB, but it works."""
@@ -1687,7 +1689,7 @@ class TestAstraDBVectorStore:
     )
     async def test_astradb_vectorstore_coreclients_init_async(
         self,
-        astra_db_credentials: Dict[str, Optional[str]],
+        astra_db_credentials: dict[str, str | None],
         core_astra_db: AstraDB,
     ) -> None:
         """A deprecation warning from passing a (core) AstraDB, but it works."""


### PR DESCRIPTION
Done with ruff auto-fix with UP006, UP007 and FA activated.
Not enforcing these rules in pyproject atm, will do it later.
These rules don't work with pydantic. FakeLLM in test_caches is the only pydantic object we have in this project so when we enforce the rule, we can maybe just ignore with noqa for these lines. 