### PR TITLE
Ruff auto-fixes

### DIFF
--- a/libs/astradb/langchain_astradb/cache.py
+++ b/libs/astradb/langchain_astradb/cache.py
@@ -67,8 +67,7 @@ def _loads_generations(generations_str: str) -> RETURN_VAL_TYPE | None:
         RETURN_VAL_TYPE: A list of generations.
     """
     try:
-        generations = [loads(_item_str) for _item_str in json.loads(generations_str)]
-        return generations
+        return [loads(_item_str) for _item_str in json.loads(generations_str)]
     except (json.JSONDecodeError, TypeError):
         # deferring the (soft) handling to after the legacy-format attempt
         pass

--- a/libs/astradb/langchain_astradb/chat_message_histories.py
+++ b/libs/astradb/langchain_astradb/chat_message_histories.py
@@ -4,10 +4,8 @@ from __future__ import annotations
 
 import json
 import time
-from typing import Sequence
+from typing import TYPE_CHECKING, Sequence
 
-from astrapy.authentication import TokenProvider
-from astrapy.db import AstraDB, AsyncAstraDB
 from langchain_core.chat_history import BaseChatMessageHistory
 from langchain_core.messages import (
     BaseMessage,
@@ -20,6 +18,10 @@ from langchain_astradb.utils.astradb import (
     SetupMode,
     _AstraDBCollectionEnvironment,
 )
+
+if TYPE_CHECKING:
+    from astrapy.authentication import TokenProvider
+    from astrapy.db import AstraDB, AsyncAstraDB
 
 DEFAULT_COLLECTION_NAME = "langchain_message_store"
 
@@ -110,8 +112,7 @@ class AstraDBChatMessageHistory(BaseChatMessageHistory):
             )
         ]
         items = [json.loads(message_blob) for message_blob in message_blobs]
-        messages = messages_from_dict(items)
-        return messages
+        return messages_from_dict(items)
 
     @messages.setter
     def messages(self, messages: list[BaseMessage]) -> None:
@@ -135,8 +136,7 @@ class AstraDBChatMessageHistory(BaseChatMessageHistory):
         )
         message_blobs = [doc["body_blob"] for doc in sorted_docs]
         items = [json.loads(message_blob) for message_blob in message_blobs]
-        messages = messages_from_dict(items)
-        return messages
+        return messages_from_dict(items)
 
     @override
     def add_messages(self, messages: Sequence[BaseMessage]) -> None:

--- a/libs/astradb/langchain_astradb/document_loaders.py
+++ b/libs/astradb/langchain_astradb/document_loaders.py
@@ -4,14 +4,13 @@ import json
 import logging
 import warnings
 from typing import (
+    TYPE_CHECKING,
     Any,
     AsyncIterator,
     Callable,
     Iterator,
 )
 
-from astrapy.authentication import TokenProvider
-from astrapy.db import AstraDB, AsyncAstraDB
 from langchain_core.document_loaders import BaseLoader
 from langchain_core.documents import Document
 from typing_extensions import override
@@ -20,6 +19,10 @@ from langchain_astradb.utils.astradb import (
     SetupMode,
     _AstraDBCollectionEnvironment,
 )
+
+if TYPE_CHECKING:
+    from astrapy.authentication import TokenProvider
+    from astrapy.db import AstraDB, AsyncAstraDB
 
 logger = logging.getLogger(__name__)
 

--- a/libs/astradb/langchain_astradb/storage.py
+++ b/libs/astradb/langchain_astradb/storage.py
@@ -5,6 +5,7 @@ import base64
 from abc import ABC, abstractmethod
 from concurrent.futures import ThreadPoolExecutor
 from typing import (
+    TYPE_CHECKING,
     Any,
     AsyncIterator,
     Generic,
@@ -13,10 +14,7 @@ from typing import (
     TypeVar,
 )
 
-from astrapy.authentication import TokenProvider
-from astrapy.db import AstraDB, AsyncAstraDB
 from astrapy.exceptions import InsertManyException
-from astrapy.results import UpdateResult
 from langchain_core.stores import BaseStore, ByteStore
 from typing_extensions import override
 
@@ -26,6 +24,11 @@ from langchain_astradb.utils.astradb import (
     SetupMode,
     _AstraDBCollectionEnvironment,
 )
+
+if TYPE_CHECKING:
+    from astrapy.authentication import TokenProvider
+    from astrapy.db import AstraDB, AsyncAstraDB
+    from astrapy.results import UpdateResult
 
 V = TypeVar("V")
 

--- a/libs/astradb/langchain_astradb/utils/astradb.py
+++ b/libs/astradb/langchain_astradb/utils/astradb.py
@@ -8,14 +8,16 @@ import os
 import warnings
 from asyncio import InvalidStateError, Task
 from enum import Enum
-from typing import Any, Awaitable
+from typing import TYPE_CHECKING, Any, Awaitable
 
 import langchain_core
 from astrapy import AsyncDatabase, DataAPIClient, Database
-from astrapy.authentication import EmbeddingHeadersProvider, TokenProvider
-from astrapy.db import AstraDB, AsyncAstraDB  # 'core' astrapy imports
 from astrapy.exceptions import DataAPIException
-from astrapy.info import CollectionDescriptor, CollectionVectorServiceOptions
+
+if TYPE_CHECKING:
+    from astrapy.authentication import EmbeddingHeadersProvider, TokenProvider
+    from astrapy.db import AstraDB, AsyncAstraDB
+    from astrapy.info import CollectionDescriptor, CollectionVectorServiceOptions
 
 TOKEN_ENV_VAR = "ASTRA_DB_APPLICATION_TOKEN"
 API_ENDPOINT_ENV_VAR = "ASTRA_DB_API_ENDPOINT"
@@ -68,10 +70,7 @@ class _AstraDBEnvironment:
                     "to AstraDBEnvironment if passing 'token', 'api_endpoint' or "
                     "'environment'."
                 )
-            if astra_db_client is not None:
-                _astra_db = astra_db_client.copy()
-            else:
-                _astra_db = None
+            _astra_db = astra_db_client.copy() if astra_db_client is not None else None
             if async_astra_db_client is not None:
                 _async_astra_db = async_astra_db_client.copy()
             else:

--- a/libs/astradb/tests/conftest.py
+++ b/libs/astradb/tests/conftest.py
@@ -29,8 +29,7 @@ class SomeEmbeddings(Embeddings):
             : self.dimension
         ]
         norm = sum(x * x for x in unnormed) ** 0.5
-        normed = [x / norm for x in unnormed]
-        return normed
+        return [x / norm for x in unnormed]
 
     async def aembed_query(self, text: str) -> list[float]:
         return self.embed_query(text)

--- a/libs/astradb/tests/integration_tests/test_caches.py
+++ b/libs/astradb/tests/integration_tests/test_caches.py
@@ -38,7 +38,7 @@ class FakeEmbeddings(Embeddings):
         """Return simple embeddings.
         Embeddings encode each text as its index.
         """
-        return [[float(1.0)] * 9 + [float(i)] for i in range(len(texts))]
+        return [[1.0] * 9 + [float(i)] for i in range(len(texts))]
 
     async def aembed_documents(self, texts: list[str]) -> list[list[float]]:
         return self.embed_documents(texts)
@@ -49,7 +49,7 @@ class FakeEmbeddings(Embeddings):
         Distance to each text will be that text's index,
         as it was passed to embed_documents.
         """
-        return [float(1.0)] * 9 + [float(0.0)]
+        return [1.0] * 9 + [0.0]
 
     async def aembed_query(self, text: str) -> list[float]:
         return self.embed_query(text)
@@ -122,7 +122,7 @@ def astradb_cache(astra_db_credentials: AstraDBCredentials) -> Iterator[AstraDBC
     cache.collection.drop()
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture()
 async def async_astradb_cache(
     astra_db_credentials: AstraDBCredentials,
 ) -> AsyncIterator[AstraDBCache]:
@@ -155,7 +155,7 @@ def astradb_semantic_cache(
     sem_cache.collection.drop()
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture()
 async def async_astradb_semantic_cache(
     astra_db_credentials: AstraDBCredentials,
 ) -> AsyncIterator[AstraDBSemanticCache]:
@@ -210,7 +210,7 @@ class TestAstraDBCaches:
         set_llm_cache(cache)
         params = llm.dict()
         params["stop"] = None
-        llm_string = str(sorted([(k, v) for k, v in params.items()]))
+        llm_string = str(sorted(params.items()))
         get_llm_cache().update("foo", llm_string, [Generation(text="fizz")])
         output = llm.generate([prompt])
         expected_output = LLMResult(
@@ -226,7 +226,7 @@ class TestAstraDBCaches:
         set_llm_cache(cache)
         params = llm.dict()
         params["stop"] = None
-        llm_string = str(sorted([(k, v) for k, v in params.items()]))
+        llm_string = str(sorted(params.items()))
         await get_llm_cache().aupdate("foo", llm_string, [Generation(text="fizz")])
         output = await llm.agenerate([prompt])
         expected_output = LLMResult(

--- a/libs/astradb/tests/integration_tests/test_chat_message_histories.py
+++ b/libs/astradb/tests/integration_tests/test_chat_message_histories.py
@@ -14,7 +14,7 @@ from langchain_astradb.utils.astradb import SetupMode
 from .conftest import AstraDBCredentials, _has_env_vars
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture()
 def history1(
     astra_db_credentials: AstraDBCredentials,
 ) -> Iterable[AstraDBChatMessageHistory]:
@@ -30,12 +30,12 @@ def history1(
     history1.collection.drop()
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture()
 def history2(
     history1: AstraDBChatMessageHistory,
     astra_db_credentials: AstraDBCredentials,
-) -> Iterable[AstraDBChatMessageHistory]:
-    history2 = AstraDBChatMessageHistory(
+) -> AstraDBChatMessageHistory:
+    return AstraDBChatMessageHistory(
         session_id="session-test-2",
         collection_name=history1.collection_name,
         token=astra_db_credentials["token"],
@@ -46,11 +46,10 @@ def history2(
         # no two createCollection calls at once are issued:
         setup_mode=SetupMode.OFF,
     )
-    yield history2
     # no deletion here, this is riding on history1
 
 
-@pytest.fixture
+@pytest.fixture()
 async def async_history1(
     astra_db_credentials: AstraDBCredentials,
 ) -> AsyncIterable[AstraDBChatMessageHistory]:
@@ -67,12 +66,12 @@ async def async_history1(
     await history1.async_collection.drop()
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture()
 async def async_history2(
     history1: AstraDBChatMessageHistory,
     astra_db_credentials: AstraDBCredentials,
-) -> AsyncIterable[AstraDBChatMessageHistory]:
-    history2 = AstraDBChatMessageHistory(
+) -> AstraDBChatMessageHistory:
+    return AstraDBChatMessageHistory(
         session_id="async-session-test-2",
         collection_name=history1.collection_name,
         token=astra_db_credentials["token"],
@@ -83,7 +82,6 @@ async def async_history2(
         # no two createCollection calls at once are issued:
         setup_mode=SetupMode.OFF,
     )
-    yield history2
     # no deletion here, this is riding on history1
 
 

--- a/libs/astradb/tests/integration_tests/test_compile.py
+++ b/libs/astradb/tests/integration_tests/test_compile.py
@@ -1,7 +1,6 @@
 import pytest
 
 
-@pytest.mark.compile
+@pytest.mark.compile()
 def test_placeholder() -> None:
     """Used for compiling integration tests without running any real tests."""
-    pass

--- a/libs/astradb/tests/integration_tests/test_document_loaders.py
+++ b/libs/astradb/tests/integration_tests/test_document_loaders.py
@@ -15,18 +15,20 @@ from __future__ import annotations
 import json
 import os
 import uuid
-from typing import AsyncIterator, Iterator
+from typing import TYPE_CHECKING, AsyncIterator, Iterator
 
 import pytest
-from astrapy import AsyncCollection, Collection, Database
-from astrapy.db import AstraDB
 
 from langchain_astradb import AstraDBLoader
 
 from .conftest import AstraDBCredentials, _has_env_vars
 
+if TYPE_CHECKING:
+    from astrapy import AsyncCollection, Collection, Database
+    from astrapy.db import AstraDB
 
-@pytest.fixture
+
+@pytest.fixture()
 def collection(database: Database) -> Iterator[Collection]:
     collection_name = f"lc_test_loader_{str(uuid.uuid4()).split('-')[0]}"
     collection = database.create_collection(collection_name)
@@ -40,7 +42,7 @@ def collection(database: Database) -> Iterator[Collection]:
     collection.drop()
 
 
-@pytest.fixture
+@pytest.fixture()
 async def async_collection(database: Database) -> AsyncIterator[AsyncCollection]:
     adatabase = database.to_async()
     collection_name = f"lc_test_loader_{str(uuid.uuid4()).split('-')[0]}"

--- a/libs/astradb/tests/integration_tests/test_storage.py
+++ b/libs/astradb/tests/integration_tests/test_storage.py
@@ -3,15 +3,18 @@
 from __future__ import annotations
 
 import os
+from typing import TYPE_CHECKING
 
 import pytest
-from astrapy import Database
-from astrapy.db import AstraDB
 
 from langchain_astradb.storage import AstraDBByteStore, AstraDBStore
 from langchain_astradb.utils.astradb import SetupMode
 
 from .conftest import _has_env_vars
+
+if TYPE_CHECKING:
+    from astrapy import Database
+    from astrapy.db import AstraDB
 
 
 def init_store(
@@ -162,8 +165,8 @@ class TestAstraDBStore:
 
             # final read (we want the IDs to do a full check)
             expected_text_by_id = {
-                **{d_id: d_tx for d_id, d_tx in zip(group0_ids, group0_texts)},
-                **{d_id: d_tx for d_id, d_tx in zip(group1_ids, group1_texts)},
+                **dict(zip(group0_ids, group0_texts)),
+                **dict(zip(group1_ids, group1_texts)),
             }
             all_ids = [doc_id for doc_id, _ in ids_and_texts]
             # The Data API can handle at most MAX_VALUES_IN_IN entries, let's chunk
@@ -227,8 +230,8 @@ class TestAstraDBStore:
 
             # final read (we want the IDs to do a full check)
             expected_text_by_id = {
-                **{d_id: d_tx for d_id, d_tx in zip(group0_ids, group0_texts)},
-                **{d_id: d_tx for d_id, d_tx in zip(group1_ids, group1_texts)},
+                **dict(zip(group0_ids, group0_texts)),
+                **dict(zip(group1_ids, group1_texts)),
             }
             all_ids = [doc_id for doc_id, _ in ids_and_texts]
             # The Data API can handle at most MAX_VALUES_IN_IN entries, let's chunk

--- a/libs/astradb/tests/unit_tests/test_vectorstores.py
+++ b/libs/astradb/tests/unit_tests/test_vectorstores.py
@@ -7,8 +7,7 @@ from langchain_astradb.vectorstores import (
     DEFAULT_INDEXING_OPTIONS,
     AstraDBVectorStore,
 )
-
-from ..conftest import SomeEmbeddings
+from tests.conftest import SomeEmbeddings
 
 
 class TestAstraDB:


### PR DESCRIPTION
Ruff auto-fix with select `ALL` excluding `D`,`UP006`, `UP007`, `FA` which are part of separate PRs.
Also excluded `EM`, `COM812`,`ISC001`, will come back to those later. 
Run with `--fix --unsafe-fixes`