### PR TITLE
Lint mmr.py

### DIFF
--- a/libs/astradb/langchain_astradb/utils/mmr.py
+++ b/libs/astradb/langchain_astradb/utils/mmr.py
@@ -7,6 +7,7 @@ are duplicated in this utility respectively from modules:
     - "libs/community/langchain_community/vectorstores/utils.py"
     - "libs/community/langchain_community/utils/math.py"
 """
+
 from __future__ import annotations
 
 import logging


### PR DESCRIPTION
A lint fix to do surfaced on main after ruff bump 0.1 => 0.5 (missing newline before annotations import in mmr.py)

This fixes that