### PR TITLE
Activate ruff PERF rule

### DIFF
--- a/libs/astradb/pyproject.toml
+++ b/libs/astradb/pyproject.toml
@@ -79,7 +79,6 @@ ignore = [
     "ERA", # Do we want to activate (no commented code) ?
     "FBT", # Do we want to activate (boolean trap) ?
     "ISC001", # Messes with the formatter
-    "PERF203", # Incorrect detection
     "PLR09", # TODO: do we enforce these ones (complexity) ?
     "PTH", # Do we want to activate (use pathlib) ?
 

--- a/libs/astradb/scripts/check_imports.py
+++ b/libs/astradb/scripts/check_imports.py
@@ -10,7 +10,7 @@ if __name__ == "__main__":
     for file in files:
         try:
             SourceFileLoader("x", file).load_module()
-        except Exception:
+        except (ImportError, FileNotFoundError):  # noqa: PERF203
             has_faillure = True
             print(file)
             traceback.print_exc()


### PR DESCRIPTION
The spirit of this rule is not to be always accurate but to point at possible perf optimization.
Even though these perf optims are rarely truly needed, it's just one rule ignore at the moment so I think it's better to simplify the ruff config.