### PR TITLE
Activate ruff ANN rules

### DIFF
--- a/libs/astradb/langchain_astradb/storage.py
+++ b/libs/astradb/langchain_astradb/storage.py
@@ -54,11 +54,11 @@ class AstraDBBaseStore(Generic[V], BaseStore[str, V], ABC):
         self.async_collection = self.astra_env.async_collection
 
     @abstractmethod
-    def decode_value(self, value: Any) -> V | None:
+    def decode_value(self, value: Any) -> V | None:  # noqa: ANN401
         """Decodes value from Astra DB."""
 
     @abstractmethod
-    def encode_value(self, value: V | None) -> Any:
+    def encode_value(self, value: V | None) -> Any:  # noqa: ANN401
         """Encodes value for Astra DB."""
 
     @override

--- a/libs/astradb/pyproject.toml
+++ b/libs/astradb/pyproject.toml
@@ -67,9 +67,10 @@ pydocstyle.convention = "google"
 pep8-naming.classmethod-decorators = [
     "langchain_core.pydantic_v1.validator",
 ]
+flake8-annotations.allow-star-arg-any = true
+flake8-annotations.mypy-init-return = true
 select = ["ALL"]
 ignore = [
-    "ANN", # Already checked by mypy
     "C90", # Do we want to activate (complexity) ?
     "COM812", # Messes with the formatter
     "ERA", # Do we want to activate (no commented code) ?


### PR DESCRIPTION
Although ruff doesn't check types, ANN rules can catch some issues much faster than mypy