### PR TITLE
Trying to make CI robust against pytest.PytestUnraisableExceptionWarning

### DIFF
--- a/libs/astradb/pyproject.toml
+++ b/libs/astradb/pyproject.toml
@@ -120,3 +120,4 @@ markers = [
   "compile: mark placeholder test used to compile integration tests without running them",
 ]
 asyncio_mode = "auto"
+filterwarnings = "ignore::pytest.PytestUnraisableExceptionWarning"

--- a/libs/astradb/tests/integration_tests/test_caches.py
+++ b/libs/astradb/tests/integration_tests/test_caches.py
@@ -263,7 +263,7 @@ class TestAstraDBCaches:
             f_rec_warnings = [
                 wrn
                 for wrn in rec_warnings
-                if not issubclass(wrn.category, ResourceWarning)
+                if issubclass(wrn.category, DeprecationWarning)
             ]
             assert len(f_rec_warnings) == 1
             assert cache_init_core.lookup("pr", "llms") == test_gens

--- a/libs/astradb/tests/integration_tests/test_caches.py
+++ b/libs/astradb/tests/integration_tests/test_caches.py
@@ -298,7 +298,12 @@ class TestAstraDBCaches:
                     astra_db_client=core_astra_db,
                     setup_mode=SetupMode.ASYNC,
                 )
-            assert len(rec_warnings) == 1
+            f_rec_warnings = [
+                wrn
+                for wrn in rec_warnings
+                if issubclass(wrn.category, DeprecationWarning)
+            ]
+            assert len(f_rec_warnings) == 1
             assert await cache_init_core.alookup("pr", "llms") == test_gens
         finally:
             await cache_init_ok.astra_env.async_database.drop_collection(
@@ -334,7 +339,12 @@ class TestAstraDBCaches:
                     astra_db_client=core_astra_db,
                     embedding=fake_embe,
                 )
-            assert len(rec_warnings) == 1
+            f_rec_warnings = [
+                wrn
+                for wrn in rec_warnings
+                if issubclass(wrn.category, DeprecationWarning)
+            ]
+            assert len(f_rec_warnings) == 1
             assert cache_init_core.lookup("pr", "llms") == test_gens
         finally:
             cache_init_ok.astra_env.database.drop_collection(collection_name)
@@ -370,7 +380,12 @@ class TestAstraDBCaches:
                     setup_mode=SetupMode.ASYNC,
                     embedding=fake_embe,
                 )
-            assert len(rec_warnings) == 1
+            f_rec_warnings = [
+                wrn
+                for wrn in rec_warnings
+                if issubclass(wrn.category, DeprecationWarning)
+            ]
+            assert len(f_rec_warnings) == 1
             assert await cache_init_core.alookup("pr", "llms") == test_gens
         finally:
             await cache_init_ok.astra_env.async_database.drop_collection(

--- a/libs/astradb/tests/integration_tests/test_caches.py
+++ b/libs/astradb/tests/integration_tests/test_caches.py
@@ -260,7 +260,12 @@ class TestAstraDBCaches:
                     collection_name=collection_name,
                     astra_db_client=core_astra_db,
                 )
-            assert len(rec_warnings) == 1
+            f_rec_warnings = [
+                wrn
+                for wrn in rec_warnings
+                if not issubclass(wrn.category, ResourceWarning)
+            ]
+            assert len(f_rec_warnings) == 1
             assert cache_init_core.lookup("pr", "llms") == test_gens
         finally:
             cache_init_ok.astra_env.database.drop_collection(collection_name)

--- a/libs/astradb/tests/integration_tests/test_chat_message_histories.py
+++ b/libs/astradb/tests/integration_tests/test_chat_message_histories.py
@@ -226,7 +226,12 @@ class TestAstraDBChatMessageHistories:
                     session_id="gattini",
                     astra_db_client=core_astra_db,
                 )
-            assert len(rec_warnings) == 1
+            f_rec_warnings = [
+                wrn
+                for wrn in rec_warnings
+                if issubclass(wrn.category, DeprecationWarning)
+            ]
+            assert len(f_rec_warnings) == 1
             assert chatmh_init_core.messages == test_messages
         finally:
             chatmh_init_ok.astra_env.collection.drop()
@@ -265,7 +270,7 @@ class TestAstraDBChatMessageHistories:
             f_rec_warnings = [
                 wrn
                 for wrn in rec_warnings
-                if not issubclass(wrn.category, ResourceWarning)
+                if issubclass(wrn.category, DeprecationWarning)
             ]
             assert len(f_rec_warnings) == 1
             assert await chatmh_init_core.aget_messages() == test_messages

--- a/libs/astradb/tests/integration_tests/test_document_loaders.py
+++ b/libs/astradb/tests/integration_tests/test_document_loaders.py
@@ -78,7 +78,10 @@ class TestAstraDB:
                 limit=22,
                 filter_criteria={"foo": "bar"},
             )
-            assert len(rec_warnings) == 1
+            f_rec_warnings = [
+                wrn for wrn in rec_warnings if issubclass(wrn.category, UserWarning)
+            ]
+            assert len(f_rec_warnings) == 1
 
         docs = loader.load()
         assert len(docs) == 22
@@ -174,9 +177,7 @@ class TestAstraDB:
             )
             # cleaning out 'spurious' "unclosed socket/transport..." warnings
             f_rec_warnings = [
-                wrn
-                for wrn in rec_warnings
-                if not issubclass(wrn.category, ResourceWarning)
+                wrn for wrn in rec_warnings if issubclass(wrn.category, UserWarning)
             ]
             assert len(f_rec_warnings) == 1
 
@@ -276,7 +277,10 @@ class TestAstraDB:
                 astra_db_client=core_astra_db,
                 limit=1,
             )
-        assert len(rec_warnings) == 1
+        f_rec_warnings = [
+            wrn for wrn in rec_warnings if issubclass(wrn.category, DeprecationWarning)
+        ]
+        assert len(f_rec_warnings) == 1
         assert loader_init_core.load() == docs
 
     def test_astradb_loader_findoptions_deprecation(
@@ -304,7 +308,10 @@ class TestAstraDB:
                 environment=astra_db_credentials["environment"],
                 find_options={"limit": 1},
             )
-        assert len(rec_warnings) == 1
+        f_rec_warnings = [
+            wrn for wrn in rec_warnings if issubclass(wrn.category, DeprecationWarning)
+        ]
+        assert len(f_rec_warnings) == 1
         assert loader_lo.load() == docs0
 
         with pytest.raises(ValueError, match="Duplicate 'limit' directive supplied."):
@@ -328,5 +335,8 @@ class TestAstraDB:
                 find_options={"planets": 8, "spiders": 40000},
                 limit=1,
             )
-        assert len(rec_warnings) == 1
+        f_rec_warnings = [
+            wrn for wrn in rec_warnings if issubclass(wrn.category, DeprecationWarning)
+        ]
+        assert len(f_rec_warnings) == 1
         assert loader_uo.load() == docs0

--- a/libs/astradb/tests/integration_tests/test_storage.py
+++ b/libs/astradb/tests/integration_tests/test_storage.py
@@ -366,7 +366,10 @@ class TestAstraDBStore:
                 namespace=astra_db_credentials["namespace"],
                 environment=astra_db_credentials["environment"],
             )
-            assert len(rec_warnings) == 1
+            f_rec_warnings = [
+                wrn for wrn in rec_warnings if issubclass(wrn.category, UserWarning)
+            ]
+            assert len(f_rec_warnings) == 1
         # on a custom collection must error
         with pytest.raises(
             ValueError, match="is detected as having the following indexing policy"
@@ -408,7 +411,12 @@ class TestAstraDBStore:
                     collection_name=collection_name,
                     astra_db_client=core_astra_db,
                 )
-            assert len(rec_warnings) == 1
+            f_rec_warnings = [
+                wrn
+                for wrn in rec_warnings
+                if issubclass(wrn.category, DeprecationWarning)
+            ]
+            assert len(f_rec_warnings) == 1
             assert store_init_core.mget(["key"]) == ["val123"]
         finally:
             store_init_ok.astra_env.database.drop_collection(collection_name)
@@ -440,7 +448,12 @@ class TestAstraDBStore:
                     astra_db_client=core_astra_db,
                     setup_mode=SetupMode.ASYNC,
                 )
-            assert len(rec_warnings) == 1
+            f_rec_warnings = [
+                wrn
+                for wrn in rec_warnings
+                if issubclass(wrn.category, DeprecationWarning)
+            ]
+            assert len(f_rec_warnings) == 1
             assert await store_init_core.amget(["key"]) == ["val123"]
         finally:
             await store_init_ok.astra_env.async_database.drop_collection(

--- a/libs/astradb/tests/integration_tests/test_vectorstores.py
+++ b/libs/astradb/tests/integration_tests/test_vectorstores.py
@@ -1492,7 +1492,10 @@ class TestAstraDBVectorStore:
                 namespace=astra_db_credentials["namespace"],
                 environment=astra_db_credentials["environment"],
             )
-            assert len(rec_warnings) == 1
+            f_rec_warnings = [
+                wrn for wrn in rec_warnings if issubclass(wrn.category, UserWarning)
+            ]
+            assert len(f_rec_warnings) == 1
 
         # cleanup
         database.drop_collection("lc_legacy_coll")
@@ -1626,9 +1629,7 @@ class TestAstraDBVectorStore:
             await leg_store.aadd_texts(["Triggering warning."])
             # cleaning out 'spurious' "unclosed socket/transport..." warnings
             f_rec_warnings = [
-                wrn
-                for wrn in rec_warnings
-                if not issubclass(wrn.category, ResourceWarning)
+                wrn for wrn in rec_warnings if issubclass(wrn.category, UserWarning)
             ]
             assert len(f_rec_warnings) == 1
 
@@ -1671,7 +1672,7 @@ class TestAstraDBVectorStore:
             f_rec_warnings = [
                 wrn
                 for wrn in rec_warnings
-                if not issubclass(wrn.category, ResourceWarning)
+                if issubclass(wrn.category, DeprecationWarning)
             ]
             assert len(f_rec_warnings) == 1
             assert len(results) == 1
@@ -1715,7 +1716,12 @@ class TestAstraDBVectorStore:
                 )
 
             results = await v_store_init_core.asimilarity_search("another", k=1)
-            assert len(rec_warnings) == 1
+            f_rec_warnings = [
+                wrn
+                for wrn in rec_warnings
+                if issubclass(wrn.category, DeprecationWarning)
+            ]
+            assert len(f_rec_warnings) == 1
             assert len(results) == 1
             assert results[0].page_content == "One text"
         finally:


### PR DESCRIPTION
Related link: https://medium.com/@BartekSkwira/how-to-solve-pytest-pytestunraisableexceptionwarning-8d75a4d1f801

The reason silencing these is important is that some tests are exactly about the number of warnings raised, so the possibility of these pytest warnings happening may mess with such test functions.