### PR TITLE
Use astrapy 1.5+ naming conventions

### DIFF
--- a/libs/astradb/langchain_astradb/cache.py
+++ b/libs/astradb/langchain_astradb/cache.py
@@ -156,7 +156,7 @@ class AstraDBCache(BaseCache):
             environment=environment,
             astra_db_client=astra_db_client,
             async_astra_db_client=async_astra_db_client,
-            namespace=namespace,
+            keyspace=namespace,
             setup_mode=setup_mode,
             pre_delete_collection=pre_delete_collection,
         )
@@ -411,7 +411,7 @@ class AstraDBSemanticCache(BaseCache):
             environment=environment,
             astra_db_client=astra_db_client,
             async_astra_db_client=async_astra_db_client,
-            namespace=namespace,
+            keyspace=namespace,
             setup_mode=setup_mode,
             pre_delete_collection=pre_delete_collection,
             embedding_dimension=embedding_dimension,

--- a/libs/astradb/langchain_astradb/chat_message_histories.py
+++ b/libs/astradb/langchain_astradb/chat_message_histories.py
@@ -81,7 +81,7 @@ class AstraDBChatMessageHistory(BaseChatMessageHistory):
             environment=environment,
             astra_db_client=astra_db_client,
             async_astra_db_client=async_astra_db_client,
-            namespace=namespace,
+            keyspace=namespace,
             setup_mode=setup_mode,
             pre_delete_collection=pre_delete_collection,
         )

--- a/libs/astradb/langchain_astradb/document_loaders.py
+++ b/libs/astradb/langchain_astradb/document_loaders.py
@@ -99,7 +99,7 @@ class AstraDBLoader(BaseLoader):
             environment=environment,
             astra_db_client=astra_db_client,
             async_astra_db_client=async_astra_db_client,
-            namespace=namespace,
+            keyspace=namespace,
             setup_mode=SetupMode.OFF,
         )
         self.astra_db_env = astra_db_env
@@ -151,7 +151,7 @@ class AstraDBLoader(BaseLoader):
         self.page_content_mapper = page_content_mapper
         self.metadata_mapper = metadata_mapper or (
             lambda _: {
-                "namespace": self.astra_db_env.database.namespace,
+                "namespace": self.astra_db_env.database.keyspace,
                 "api_endpoint": self.astra_db_env.database.api_endpoint,
                 "collection": collection_name,
             }

--- a/libs/astradb/langchain_astradb/storage.py
+++ b/libs/astradb/langchain_astradb/storage.py
@@ -46,6 +46,10 @@ class AstraDBBaseStore(Generic[V], BaseStore[str, V], ABC):
             raise ValueError(msg)
         kwargs["requested_indexing_policy"] = {"allow": ["_id"]}
         kwargs["default_indexing_policy"] = {"allow": ["_id"]}
+
+        if "namespace" in kwargs:
+            kwargs["keyspace"] = kwargs.pop("namespace")
+
         self.astra_env = _AstraDBCollectionEnvironment(
             *args,
             **kwargs,

--- a/libs/astradb/langchain_astradb/utils/astradb.py
+++ b/libs/astradb/langchain_astradb/utils/astradb.py
@@ -23,7 +23,7 @@ if TYPE_CHECKING:
 
 TOKEN_ENV_VAR = "ASTRA_DB_APPLICATION_TOKEN"  # noqa: S105
 API_ENDPOINT_ENV_VAR = "ASTRA_DB_API_ENDPOINT"
-NAMESPACE_ENV_VAR = "ASTRA_DB_KEYSPACE"
+KEYSPACE_ENV_VAR = "ASTRA_DB_KEYSPACE"
 
 # Default settings for API data operations (concurrency & similar):
 # Chunk size for many-document insertions (None meaning defer to astrapy):
@@ -57,7 +57,7 @@ def _survey_collection(
     environment: str | None = None,
     astra_db_client: AstraDB | None = None,
     async_astra_db_client: AsyncAstraDB | None = None,
-    namespace: str | None = None,
+    keyspace: str | None = None,
 ) -> tuple[CollectionDescriptor | None, list[dict[str, Any]]]:
     """Return the collection descriptor (if found) and a sample of documents."""
     _environment = _AstraDBEnvironment(
@@ -66,7 +66,7 @@ def _survey_collection(
         environment=environment,
         astra_db_client=astra_db_client,
         async_astra_db_client=async_astra_db_client,
-        namespace=namespace,
+        keyspace=keyspace,
     )
     descriptors = [
         coll_d
@@ -93,11 +93,11 @@ class _AstraDBEnvironment:
         environment: str | None = None,
         astra_db_client: AstraDB | None = None,
         async_astra_db_client: AsyncAstraDB | None = None,
-        namespace: str | None = None,
+        keyspace: str | None = None,
     ) -> None:
         self.token: str | TokenProvider | None
         self.api_endpoint: str | None
-        self.namespace: str | None
+        self.keyspace: str | None
         self.environment: str | None
 
         self.data_api_client: DataAPIClient
@@ -147,7 +147,7 @@ class _AstraDBEnvironment:
                     if klient is not None
                 }
             )
-            _namespaces = list(
+            _keyspaces = list(
                 {
                     klient.namespace
                     for klient in [astra_db_client, async_astra_db_client]
@@ -164,21 +164,21 @@ class _AstraDBEnvironment:
             if len(_api_endpoints) != 1:
                 msg = (
                     "Conflicting API endpoints found in the sync and async "
-                    "AstraDB constructor parameters. Please check the tokens "
+                    "AstraDB constructor parameters. Please check the endpoints "
                     "and ensure they match."
                 )
                 raise ValueError(msg)
-            if len(_namespaces) != 1:
+            if len(_keyspaces) != 1:
                 msg = (
-                    "Conflicting namespaces found in the sync and async "
-                    "AstraDB constructor parameters. Please check the tokens "
-                    "and ensure they match."
+                    "Conflicting keyspaces found in the sync and async "
+                    "AstraDB constructor parameters' 'namespace' attributes. "
+                    "Please check the keyspaces and ensure they match."
                 )
                 raise ValueError(msg)
             # all good: these are 1-element lists here
             self.token = _tokens[0]
             self.api_endpoint = _api_endpoints[0]
-            self.namespace = _namespaces[0]
+            self.keyspace = _keyspaces[0]
         else:
             _token: str | TokenProvider | None
             # secrets-based initialization
@@ -199,19 +199,19 @@ class _AstraDBEnvironment:
                 _api_endpoint = os.environ.get(API_ENDPOINT_ENV_VAR)
             else:
                 _api_endpoint = api_endpoint
-            if namespace is None:
-                _namespace = os.environ.get(NAMESPACE_ENV_VAR)
+            if keyspace is None:
+                _keyspace = os.environ.get(KEYSPACE_ENV_VAR)
             else:
-                _namespace = namespace
+                _keyspace = keyspace
 
             self.token = _token
             self.api_endpoint = _api_endpoint
-            self.namespace = _namespace
+            self.keyspace = _keyspace
 
         self.environment = environment
 
-        # init parameters are normalized to self.{token, api_endpoint, namespace}.
-        # Proceed. Namespace and token can be None (resp. on Astra DB and non-Astra)
+        # init parameters are normalized to self.{token, api_endpoint, keyspace}.
+        # Proceed. Keyspace and token can be None (resp. on Astra DB and non-Astra)
         if self.api_endpoint is None:
             msg = (
                 "API endpoint for Data API not provided. "
@@ -232,7 +232,7 @@ class _AstraDBEnvironment:
         self.database = self.data_api_client.get_database(
             api_endpoint=self.api_endpoint,
             token=self.token,
-            keyspace=self.namespace,
+            keyspace=self.keyspace,
         )
         self.async_database = self.database.to_async()
 
@@ -247,7 +247,7 @@ class _AstraDBCollectionEnvironment(_AstraDBEnvironment):
         environment: str | None = None,
         astra_db_client: AstraDB | None = None,
         async_astra_db_client: AsyncAstraDB | None = None,
-        namespace: str | None = None,
+        keyspace: str | None = None,
         setup_mode: SetupMode = SetupMode.SYNC,
         pre_delete_collection: bool = False,
         embedding_dimension: int | Awaitable[int] | None = None,
@@ -263,7 +263,7 @@ class _AstraDBCollectionEnvironment(_AstraDBEnvironment):
             environment=environment,
             astra_db_client=astra_db_client,
             async_astra_db_client=async_astra_db_client,
-            namespace=namespace,
+            keyspace=keyspace,
         )
         self.collection_name = collection_name
         self.collection = self.database.get_collection(

--- a/libs/astradb/langchain_astradb/vectorstores.py
+++ b/libs/astradb/langchain_astradb/vectorstores.py
@@ -597,7 +597,7 @@ class AstraDBVectorStore(VectorStore):
                 environment=self.environment,
                 astra_db_client=astra_db_client,
                 async_astra_db_client=async_astra_db_client,
-                namespace=self.namespace,
+                keyspace=self.namespace,
             )
             if c_descriptor is None:
                 msg = f"Collection '{self.collection_name}' not found."
@@ -653,7 +653,7 @@ class AstraDBVectorStore(VectorStore):
             environment=self.environment,
             astra_db_client=astra_db_client,
             async_astra_db_client=async_astra_db_client,
-            namespace=self.namespace,
+            keyspace=self.namespace,
             setup_mode=_setup_mode,
             pre_delete_collection=pre_delete_collection,
             embedding_dimension=_embedding_dimension,

--- a/libs/astradb/tests/integration_tests/conftest.py
+++ b/libs/astradb/tests/integration_tests/conftest.py
@@ -175,7 +175,7 @@ def database(
     db = client.get_database(
         astra_db_credentials["api_endpoint"],
         token=StaticTokenProvider(astra_db_credentials["token"]),
-        namespace=astra_db_credentials["namespace"],
+        keyspace=astra_db_credentials["namespace"],
     )
     if not is_astra_db:
         if astra_db_credentials["namespace"] is None:

--- a/libs/astradb/tests/integration_tests/test_document_loaders.py
+++ b/libs/astradb/tests/integration_tests/test_document_loaders.py
@@ -96,7 +96,7 @@ class TestAstraDB:
             assert content["_id"] not in ids
             ids.add(content["_id"])
             assert doc.metadata == {
-                "namespace": database.namespace,
+                "namespace": database.keyspace,
                 "api_endpoint": astra_db_credentials["api_endpoint"],
                 "collection": document_loader_collection.name,
             }
@@ -189,7 +189,7 @@ class TestAstraDB:
             assert content["_id"] not in ids
             ids.add(content["_id"])
             assert doc.metadata == {
-                "namespace": database.namespace,
+                "namespace": database.keyspace,
                 "api_endpoint": astra_db_credentials["api_endpoint"],
                 "collection": async_document_loader_collection.name,
             }
@@ -234,7 +234,7 @@ class TestAstraDB:
             assert content["_id"] not in ids
             ids.add(content["_id"])
             assert doc.metadata == {
-                "namespace": database.namespace,
+                "namespace": database.keyspace,
                 "api_endpoint": astra_db_credentials["api_endpoint"],
                 "collection": async_document_loader_collection.name,
             }

--- a/libs/astradb/tests/unit_tests/test_astra_db_environment.py
+++ b/libs/astradb/tests/unit_tests/test_astra_db_environment.py
@@ -5,7 +5,7 @@ from astrapy.db import AstraDB
 
 from langchain_astradb.utils.astradb import (
     API_ENDPOINT_ENV_VAR,
-    NAMESPACE_ENV_VAR,
+    KEYSPACE_ENV_VAR,
     TOKEN_ENV_VAR,
     _AstraDBEnvironment,
 )
@@ -47,15 +47,15 @@ class TestAstraDBEnvironment:
                     API_ENDPOINT_ENV_VAR
                 ]
                 del os.environ[API_ENDPOINT_ENV_VAR]
-            if NAMESPACE_ENV_VAR in os.environ:
-                env_vars_to_restore[NAMESPACE_ENV_VAR] = os.environ[NAMESPACE_ENV_VAR]
-                del os.environ[NAMESPACE_ENV_VAR]
+            if KEYSPACE_ENV_VAR in os.environ:
+                env_vars_to_restore[KEYSPACE_ENV_VAR] = os.environ[KEYSPACE_ENV_VAR]
+                del os.environ[KEYSPACE_ENV_VAR]
 
             # token+endpoint
             env1 = _AstraDBEnvironment(
                 token=FAKE_TOKEN,
                 api_endpoint=a_e_string,
-                namespace="n",
+                keyspace="n",
             )
 
             # through a core AstraDB instance
@@ -126,7 +126,7 @@ class TestAstraDBEnvironment:
                 )
             with pytest.raises(
                 ValueError,
-                match="Conflicting namespaces found in the sync and async AstraDB "
+                match="Conflicting keyspaces found in the sync and async AstraDB "
                 "constructor parameters.",
             ), pytest.warns(DeprecationWarning):
                 _AstraDBEnvironment(
@@ -174,7 +174,7 @@ class TestAstraDBEnvironment:
             os.environ[TOKEN_ENV_VAR] = "t"
             env4 = _AstraDBEnvironment(
                 api_endpoint=a_e_string,
-                namespace="n",
+                keyspace="n",
             )
             del os.environ[TOKEN_ENV_VAR]
             assert env1.data_api_client == env4.data_api_client
@@ -185,7 +185,7 @@ class TestAstraDBEnvironment:
             os.environ[API_ENDPOINT_ENV_VAR] = a_e_string
             env5 = _AstraDBEnvironment(
                 token=FAKE_TOKEN,
-                namespace="n",
+                keyspace="n",
             )
             del os.environ[API_ENDPOINT_ENV_VAR]
             assert env1.data_api_client == env5.data_api_client
@@ -195,19 +195,19 @@ class TestAstraDBEnvironment:
             # both and also namespace via env vars
             os.environ[TOKEN_ENV_VAR] = FAKE_TOKEN
             os.environ[API_ENDPOINT_ENV_VAR] = a_e_string
-            os.environ[NAMESPACE_ENV_VAR] = "n"
+            os.environ[KEYSPACE_ENV_VAR] = "n"
             env6 = _AstraDBEnvironment()
             assert env1.data_api_client == env6.data_api_client
             assert env1.database == env6.database
             assert env1.async_database == env6.async_database
             del os.environ[TOKEN_ENV_VAR]
             del os.environ[API_ENDPOINT_ENV_VAR]
-            del os.environ[NAMESPACE_ENV_VAR]
+            del os.environ[KEYSPACE_ENV_VAR]
 
             # env vars do not interfere if client(s) passed
             os.environ[TOKEN_ENV_VAR] = "NO!"
             os.environ[API_ENDPOINT_ENV_VAR] = "NO!"
-            os.environ[NAMESPACE_ENV_VAR] = "NO!"
+            os.environ[KEYSPACE_ENV_VAR] = "NO!"
             with pytest.warns(DeprecationWarning):
                 env7a = _AstraDBEnvironment(
                     async_astra_db_client=mock_astra_db.to_async(),
@@ -235,7 +235,7 @@ class TestAstraDBEnvironment:
             env8 = _AstraDBEnvironment(
                 token=FAKE_TOKEN,
                 api_endpoint=a_e_string,
-                namespace="n",
+                keyspace="n",
             )
             assert env1.data_api_client == env8.data_api_client
             assert env1.database == env8.database
@@ -247,7 +247,7 @@ class TestAstraDBEnvironment:
                 del os.environ[TOKEN_ENV_VAR]
             if API_ENDPOINT_ENV_VAR in os.environ:
                 del os.environ[API_ENDPOINT_ENV_VAR]
-            if NAMESPACE_ENV_VAR in os.environ:
-                del os.environ[NAMESPACE_ENV_VAR]
+            if KEYSPACE_ENV_VAR in os.environ:
+                del os.environ[KEYSPACE_ENV_VAR]
             for env_var_name, env_var_value in env_vars_to_restore.items():
                 os.environ[env_var_name] = env_var_value


### PR DESCRIPTION
Astrapy 1.5+ deprecates the use of "namespace" in favour of "keyspace". This PR, while keeping all langchain interface and behaviour unchanged, adapts to this change in a purely internal fashion.

(Edit: a side benefit is that the tests run with 170 fewer DeprecationWarnings)