### PR TITLE
Add [a]delete_by_metadata and [a]update_metadata methods to vector store

### DIFF
--- a/libs/astradb/langchain_astradb/vectorstores.py
+++ b/libs/astradb/langchain_astradb/vectorstores.py
@@ -827,6 +827,62 @@ class AstraDBVectorStore(VectorStore):
         )
         return True
 
+    def delete_by_metadata_filter(
+        self,
+        filter: dict[str, Any],  # noqa: A002
+    ) -> int | None:
+        """Delete all documents matching a certain metadata filtering condition.
+
+        This operation does not use the vector embeddings in any way, it simply
+        removes all documents whose metadata match the provided condition.
+        Use with caution: passing an empty filter dictionary results in
+        completely emptying the vector store.
+
+        Args:
+            filter: Filter on the metadata to apply.
+
+        Returns:
+            An number expressing the amount of deleted documents.
+            This will be None if a `{}` metadata filter condition is passed,
+            implying emptying the store entirely.
+        """
+        self.astra_env.ensure_db_setup()
+        metadata_parameter = self.filter_to_query(filter)
+        del_result = self.astra_env.collection.delete_many(
+            filter=metadata_parameter,
+        )
+        if del_result.deleted_count is not None and del_result.deleted_count >= 0:
+            return del_result.deleted_count
+        return None
+
+    async def adelete_by_metadata_filter(
+        self,
+        filter: dict[str, Any],  # noqa: A002
+    ) -> int | None:
+        """Delete all documents matching a certain metadata filtering condition.
+
+        This operation does not use the vector embeddings in any way, it simply
+        removes all documents whose metadata match the provided condition.
+        Use with caution: passing an empty filter dictionary results in
+        completely emptying the vector store.
+
+        Args:
+            filter: Filter on the metadata to apply.
+
+        Returns:
+            An number expressing the amount of deleted documents.
+            This will be None if a `{}` metadata filter condition is passed,
+            implying emptying the store entirely.
+        """
+        await self.astra_env.aensure_db_setup()
+        metadata_parameter = self.filter_to_query(filter)
+        del_result = await self.astra_env.async_collection.delete_many(
+            filter=metadata_parameter,
+        )
+        if del_result.deleted_count is not None and del_result.deleted_count >= 0:
+            return del_result.deleted_count
+        return None
+
     def delete_collection(self) -> None:
         """Completely delete the collection from the database.
 

--- a/libs/astradb/langchain_astradb/vectorstores.py
+++ b/libs/astradb/langchain_astradb/vectorstores.py
@@ -830,58 +830,60 @@ class AstraDBVectorStore(VectorStore):
     def delete_by_metadata_filter(
         self,
         filter: dict[str, Any],  # noqa: A002
-    ) -> int | None:
+    ) -> int:
         """Delete all documents matching a certain metadata filtering condition.
 
         This operation does not use the vector embeddings in any way, it simply
         removes all documents whose metadata match the provided condition.
-        Use with caution: passing an empty filter dictionary results in
-        completely emptying the vector store.
 
         Args:
-            filter: Filter on the metadata to apply.
+            filter: Filter on the metadata to apply. The filter cannot be empty.
 
         Returns:
             An number expressing the amount of deleted documents.
-            This will be None if a `{}` metadata filter condition is passed,
-            implying emptying the store entirely.
         """
+        if not filter:
+            msg = (
+                "Method `delete_by_metadata_filter` does not accept an empty "
+                "filter. Use the `clear()` method if you really want to empty "
+                "the vector store."
+            )
+            raise ValueError(msg)
         self.astra_env.ensure_db_setup()
         metadata_parameter = self.filter_to_query(filter)
         del_result = self.astra_env.collection.delete_many(
             filter=metadata_parameter,
         )
-        if del_result.deleted_count is not None and del_result.deleted_count >= 0:
-            return del_result.deleted_count
-        return None
+        return del_result.deleted_count or 0
 
     async def adelete_by_metadata_filter(
         self,
         filter: dict[str, Any],  # noqa: A002
-    ) -> int | None:
+    ) -> int:
         """Delete all documents matching a certain metadata filtering condition.
 
         This operation does not use the vector embeddings in any way, it simply
         removes all documents whose metadata match the provided condition.
-        Use with caution: passing an empty filter dictionary results in
-        completely emptying the vector store.
 
         Args:
-            filter: Filter on the metadata to apply.
+            filter: Filter on the metadata to apply. The filter cannot be empty.
 
         Returns:
             An number expressing the amount of deleted documents.
-            This will be None if a `{}` metadata filter condition is passed,
-            implying emptying the store entirely.
         """
+        if not filter:
+            msg = (
+                "Method `delete_by_metadata_filter` does not accept an empty "
+                "filter. Use the `clear()` method if you really want to empty "
+                "the vector store."
+            )
+            raise ValueError(msg)
         await self.astra_env.aensure_db_setup()
         metadata_parameter = self.filter_to_query(filter)
         del_result = await self.astra_env.async_collection.delete_many(
             filter=metadata_parameter,
         )
-        if del_result.deleted_count is not None and del_result.deleted_count >= 0:
-            return del_result.deleted_count
-        return None
+        return del_result.deleted_count or 0
 
     def delete_collection(self) -> None:
         """Completely delete the collection from the database.
@@ -1230,7 +1232,7 @@ class AstraDBVectorStore(VectorStore):
     ) -> int:
         """Add/overwrite the metadata of existing documents.
 
-        For each document to update, the new metadata dictionary is added
+        For each document to update, the new metadata dictionary is appended
         to the existing metadata, overwriting individual keys that existed already.
 
         Args:
@@ -1281,7 +1283,7 @@ class AstraDBVectorStore(VectorStore):
     ) -> int:
         """Add/overwrite the metadata of existing documents.
 
-        For each document to update, the new metadata dictionary is added
+        For each document to update, the new metadata dictionary is appended
         to the existing metadata, overwriting individual keys that existed already.
 
         Args:

--- a/libs/astradb/tests/integration_tests/test_vectorstore.py
+++ b/libs/astradb/tests/integration_tests/test_vectorstore.py
@@ -834,17 +834,24 @@ class TestAstraDBVectorStore:
             )
             for doc_i in range(full_size)
         ]
+        num_deletees = len([doc for doc in documents if doc.metadata["deletee"]])
 
         inserted_ids0 = vector_store_d2.add_documents(documents)
         assert len(inserted_ids0) == len(documents)
 
         d_result0 = vector_store_d2.delete_by_metadata_filter({"deletee": True})
-        assert d_result0 is not None
-        assert d_result0 == len([doc for doc in documents if doc.metadata["deletee"]])
+        assert d_result0 == num_deletees
+        count_on_store0 = len(
+            vector_store_d2.similarity_search("[1,1]", k=full_size + 1)
+        )
+        assert count_on_store0 == full_size - num_deletees
 
-        d_result1 = vector_store_d2.delete_by_metadata_filter({})
-        assert d_result1 is None
-        assert len(vector_store_d2.similarity_search("[1,1]", k=1)) == 0
+        with pytest.raises(ValueError, match="does not accept an empty"):
+            vector_store_d2.delete_by_metadata_filter({})
+        count_on_store1 = len(
+            vector_store_d2.similarity_search("[1,1]", k=full_size + 1)
+        )
+        assert count_on_store1 == full_size - num_deletees
 
     async def test_astradb_vectorstore_delete_by_metadata_async(
         self,
@@ -861,17 +868,24 @@ class TestAstraDBVectorStore:
             )
             for doc_i in range(full_size)
         ]
+        num_deletees = len([doc for doc in documents if doc.metadata["deletee"]])
 
         inserted_ids0 = await vector_store_d2.aadd_documents(documents)
         assert len(inserted_ids0) == len(documents)
 
         d_result0 = await vector_store_d2.adelete_by_metadata_filter({"deletee": True})
-        assert d_result0 is not None
-        assert d_result0 == len([doc for doc in documents if doc.metadata["deletee"]])
+        assert d_result0 == num_deletees
+        count_on_store0 = len(
+            await vector_store_d2.asimilarity_search("[1,1]", k=full_size + 1)
+        )
+        assert count_on_store0 == full_size - num_deletees
 
-        d_result1 = await vector_store_d2.adelete_by_metadata_filter({})
-        assert d_result1 is None
-        assert len(await vector_store_d2.asimilarity_search("[1,1]", k=1)) == 0
+        with pytest.raises(ValueError, match="does not accept an empty"):
+            await vector_store_d2.adelete_by_metadata_filter({})
+        count_on_store1 = len(
+            await vector_store_d2.asimilarity_search("[1,1]", k=full_size + 1)
+        )
+        assert count_on_store1 == full_size - num_deletees
 
     def test_astradb_vectorstore_update_metadata_sync(
         self,

--- a/libs/astradb/tests/integration_tests/test_vectorstore_autodetect.py
+++ b/libs/astradb/tests/integration_tests/test_vectorstore_autodetect.py
@@ -92,6 +92,13 @@ class TestAstraDBVectorStoreAutodetect:
         results2 = ad_store.similarity_search("[-1,-1]", k=3, filter={"q2": "Q2"})
         assert results2 == [Document(id=id4, page_content=pc4, metadata=md4)]
 
+        # delete by metadata
+        del_by_md = ad_store.delete_by_metadata_filter(filter={"q2": "Q2"})
+        assert del_by_md is not None
+        assert del_by_md == 1
+        results2n = ad_store.similarity_search("[-1,-1]", k=3, filter={"q2": "Q2"})
+        assert results2n == []
+
     def test_autodetect_default_novectorize_crud(
         self,
         astra_db_credentials: AstraDBCredentials,
@@ -147,6 +154,13 @@ class TestAstraDBVectorStoreAutodetect:
         # reading with filtering
         results2 = ad_store.similarity_search("[9,10]", k=3, filter={"q2": "Q2"})
         assert results2 == [Document(id=id4, page_content=pc4, metadata=md4)]
+
+        # delete by metadata
+        del_by_md = ad_store.delete_by_metadata_filter(filter={"q2": "Q2"})
+        assert del_by_md is not None
+        assert del_by_md == 1
+        results2n = ad_store.similarity_search("[-1,-1]", k=3, filter={"q2": "Q2"})
+        assert results2n == []
 
     def test_autodetect_flat_vectorize_crud(
         self,
@@ -208,6 +222,13 @@ class TestAstraDBVectorStoreAutodetect:
         results2 = ad_store.similarity_search("query", k=3, filter={"q2": "Q2"})
         assert results2 == [Document(id=id4, page_content=pc4, metadata=md4)]
 
+        # delete by metadata
+        del_by_md = ad_store.delete_by_metadata_filter(filter={"q2": "Q2"})
+        assert del_by_md is not None
+        assert del_by_md == 1
+        results2n = ad_store.similarity_search("[-1,-1]", k=3, filter={"q2": "Q2"})
+        assert results2n == []
+
     def test_autodetect_default_vectorize_crud(
         self,
         *,
@@ -265,6 +286,13 @@ class TestAstraDBVectorStoreAutodetect:
         # reading with filtering
         results2 = ad_store.similarity_search("query", k=3, filter={"q2": "Q2"})
         assert results2 == [Document(id=id4, page_content=pc4, metadata=md4)]
+
+        # delete by metadata
+        del_by_md = ad_store.delete_by_metadata_filter(filter={"q2": "Q2"})
+        assert del_by_md is not None
+        assert del_by_md == 1
+        results2n = ad_store.similarity_search("[-1,-1]", k=3, filter={"q2": "Q2"})
+        assert results2n == []
 
     def test_failed_docs_autodetect_flat_novectorize_crud(
         self,

--- a/libs/astradb/tests/integration_tests/test_vectorstore_autodetect.py
+++ b/libs/astradb/tests/integration_tests/test_vectorstore_autodetect.py
@@ -99,6 +99,19 @@ class TestAstraDBVectorStoreAutodetect:
         results2n = ad_store.similarity_search("[-1,-1]", k=3, filter={"q2": "Q2"})
         assert results2n == []
 
+        def doc_sorter(doc: Document) -> str:
+            return doc.id or ""
+
+        # update metadata
+        ad_store.update_metadata(
+            {"1": {"m1": "A", "mZ": "Z"}, "2": {"m1": "B", "mZ": "Z"}}
+        )
+        matches_z = ad_store.similarity_search("[-1,-1]", k=3, filter={"mZ": "Z"})
+        assert len(matches_z) == 2
+        s_matches_z = sorted(matches_z, key=doc_sorter)
+        assert s_matches_z[0].metadata == {"m1": "A", "m2": "x", "mZ": "Z"}
+        assert s_matches_z[1].metadata == {"m1": "B", "m2": "y", "mZ": "Z"}
+
     def test_autodetect_default_novectorize_crud(
         self,
         astra_db_credentials: AstraDBCredentials,
@@ -161,6 +174,19 @@ class TestAstraDBVectorStoreAutodetect:
         assert del_by_md == 1
         results2n = ad_store.similarity_search("[-1,-1]", k=3, filter={"q2": "Q2"})
         assert results2n == []
+
+        def doc_sorter(doc: Document) -> str:
+            return doc.id or ""
+
+        # update metadata
+        ad_store.update_metadata(
+            {"1": {"m1": "A", "mZ": "Z"}, "2": {"m1": "B", "mZ": "Z"}}
+        )
+        matches_z = ad_store.similarity_search("[-1,-1]", k=3, filter={"mZ": "Z"})
+        assert len(matches_z) == 2
+        s_matches_z = sorted(matches_z, key=doc_sorter)
+        assert s_matches_z[0].metadata == {"m1": "A", "m2": "x", "mZ": "Z"}
+        assert s_matches_z[1].metadata == {"m1": "B", "m2": "y", "mZ": "Z"}
 
     def test_autodetect_flat_vectorize_crud(
         self,
@@ -229,6 +255,19 @@ class TestAstraDBVectorStoreAutodetect:
         results2n = ad_store.similarity_search("[-1,-1]", k=3, filter={"q2": "Q2"})
         assert results2n == []
 
+        def doc_sorter(doc: Document) -> str:
+            return doc.id or ""
+
+        # update metadata
+        ad_store.update_metadata(
+            {"1": {"m1": "A", "mZ": "Z"}, "2": {"m1": "B", "mZ": "Z"}}
+        )
+        matches_z = ad_store.similarity_search("[-1,-1]", k=3, filter={"mZ": "Z"})
+        assert len(matches_z) == 2
+        s_matches_z = sorted(matches_z, key=doc_sorter)
+        assert s_matches_z[0].metadata == {"m1": "A", "m2": "x", "mZ": "Z"}
+        assert s_matches_z[1].metadata == {"m1": "B", "m2": "y", "mZ": "Z"}
+
     def test_autodetect_default_vectorize_crud(
         self,
         *,
@@ -293,6 +332,19 @@ class TestAstraDBVectorStoreAutodetect:
         assert del_by_md == 1
         results2n = ad_store.similarity_search("[-1,-1]", k=3, filter={"q2": "Q2"})
         assert results2n == []
+
+        def doc_sorter(doc: Document) -> str:
+            return doc.id or ""
+
+        # update metadata
+        ad_store.update_metadata(
+            {"1": {"m1": "A", "mZ": "Z"}, "2": {"m1": "B", "mZ": "Z"}}
+        )
+        matches_z = ad_store.similarity_search("[-1,-1]", k=3, filter={"mZ": "Z"})
+        assert len(matches_z) == 2
+        s_matches_z = sorted(matches_z, key=doc_sorter)
+        assert s_matches_z[0].metadata == {"m1": "A", "m2": "x", "mZ": "Z"}
+        assert s_matches_z[1].metadata == {"m1": "B", "m2": "y", "mZ": "Z"}
 
     def test_failed_docs_autodetect_flat_novectorize_crud(
         self,


### PR DESCRIPTION
This PR adds four methods to the vector store, the a/sync versions of:

- update metadata (of several documents at once). This has the semantic of updating a dictionary, i.e. old keys are not lost and overlapping keys are overridden;
- delete (a number of documents) by a metadata filter.

These methods are needed by the operation of "promoting" a vector store to a graph vector store.