### PR TITLE
Improved handling of multidoc insertion errors for vector store

### DIFF
--- a/libs/astradb/langchain_astradb/__init__.py
+++ b/libs/astradb/langchain_astradb/__init__.py
@@ -7,7 +7,7 @@ from langchain_astradb.chat_message_histories import AstraDBChatMessageHistory
 from langchain_astradb.document_loaders import AstraDBLoader
 from langchain_astradb.graph_vectorstores import AstraDBGraphVectorStore
 from langchain_astradb.storage import AstraDBByteStore, AstraDBStore
-from langchain_astradb.vectorstores import AstraDBVectorStore
+from langchain_astradb.vectorstores import AstraDBVectorStore, AstraDBVectorStoreError
 
 __all__ = [
     "AstraDBByteStore",
@@ -18,5 +18,6 @@ __all__ = [
     "AstraDBSemanticCache",
     "AstraDBStore",
     "AstraDBVectorStore",
+    "AstraDBVectorStoreError",
     "CollectionVectorServiceOptions",
 ]

--- a/libs/astradb/langchain_astradb/vectorstores.py
+++ b/libs/astradb/langchain_astradb/vectorstores.py
@@ -1085,9 +1085,14 @@ class AstraDBVectorStore(VectorStore):
                     there_s_more = f". (Note: {num_residual} further errors omitted.)"
                 else:
                     there_s_more = ""
+                original_err_note = (
+                    " (Full API error in '<this-exception>.__cause__.error_descriptors'"
+                    f": ignore '{DOCUMENT_ALREADY_EXISTS_API_ERROR_CODE}'.)"
+                )
                 full_err_message = (
                     "Cannot insert documents. The Data API returned the "
-                    f"following error(s): {all_err_descs}{there_s_more}"
+                    f"following error(s): {all_err_descs}"
+                    f"{there_s_more}{original_err_note}"
                 )
                 raise ValueError(full_err_message) from err
 
@@ -1239,9 +1244,14 @@ class AstraDBVectorStore(VectorStore):
                     there_s_more = f". (Note: {num_residual} further errors omitted.)"
                 else:
                     there_s_more = ""
+                original_err_note = (
+                    " (Full API error in '<this-exception>.__cause__.error_descriptors'"
+                    f": ignore '{DOCUMENT_ALREADY_EXISTS_API_ERROR_CODE}'.)"
+                )
                 full_err_message = (
                     "Cannot insert documents. The Data API returned the "
-                    f"following error(s): {all_err_descs}{there_s_more}"
+                    f"following error(s): {all_err_descs}"
+                    f"{there_s_more}{original_err_note}"
                 )
                 raise ValueError(full_err_message) from err
 

--- a/libs/astradb/langchain_astradb/vectorstores.py
+++ b/libs/astradb/langchain_astradb/vectorstores.py
@@ -170,11 +170,8 @@ def _insertmany_error_message(err: InsertManyException) -> str:
         for edesc in filtered_error_descs[:MAX_SHOWN_INSERTION_ERRORS]
     )
 
-    if len(filtered_error_descs) > MAX_SHOWN_INSERTION_ERRORS:
-        err_msg += (
-            f". (Note: {len(filtered_error_descs) - MAX_SHOWN_INSERTION_ERRORS}"
-            " further errors omitted.)"
-        )
+    if (num_residual := len(filtered_error_descs) - MAX_SHOWN_INSERTION_ERRORS) > 0:
+        err_msg += f". (Note: {num_residual} further errors omitted.)"
 
     err_msg += (
         " (Full API error in '<this-exception>.__cause__.error_descriptors'"

--- a/libs/astradb/langchain_astradb/vectorstores.py
+++ b/libs/astradb/langchain_astradb/vectorstores.py
@@ -67,6 +67,8 @@ DocDict = Dict[str, Any]  # dicts expressing entries to insert
 DEFAULT_INDEXING_OPTIONS = {"allow": ["metadata"]}
 # error code to check for during bulk insertions
 DOCUMENT_ALREADY_EXISTS_API_ERROR_CODE = "DOCUMENT_ALREADY_EXISTS"
+# max number of errors shown in full insertion error messages
+MAX_SHOWN_INSERTION_ERRORS = 8
 
 logger = logging.getLogger(__name__)
 
@@ -1065,15 +1067,27 @@ class AstraDBVectorStore(VectorStore):
                 # Raise a non-astrapy error with a message covering all errors
                 # except the DOCUMENT_ALREADY_EXISTS_API_ERROR_CODE, which this
                 # method can handle (if they were the only error)
-                all_err_descs = "; ".join(
-                    edesc.message
+                filtered_error_descs = [
+                    edesc
                     for edesc in err.error_descriptors
                     if edesc.error_code != DOCUMENT_ALREADY_EXISTS_API_ERROR_CODE
                     if edesc.message
+                ]
+                all_err_descs = "; ".join(
+                    edesc.message or ""
+                    for edesc in filtered_error_descs[:MAX_SHOWN_INSERTION_ERRORS]
                 )
+                there_s_more: str
+                if len(filtered_error_descs) > MAX_SHOWN_INSERTION_ERRORS:
+                    num_residual = (
+                        len(filtered_error_descs) - MAX_SHOWN_INSERTION_ERRORS
+                    )
+                    there_s_more = f". (Note: {num_residual} further errors omitted.)"
+                else:
+                    there_s_more = ""
                 full_err_message = (
                     "Cannot insert documents. The Data API returned the "
-                    f"following error(s): {all_err_descs}"
+                    f"following error(s): {all_err_descs}{there_s_more}"
                 )
                 raise ValueError(full_err_message) from err
 
@@ -1207,15 +1221,27 @@ class AstraDBVectorStore(VectorStore):
                 # Raise a non-astrapy error with a message covering all errors
                 # except the DOCUMENT_ALREADY_EXISTS_API_ERROR_CODE, which this
                 # method can handle (if they were the only error)
-                all_err_descs = "; ".join(
-                    edesc.message
+                filtered_error_descs = [
+                    edesc
                     for edesc in err.error_descriptors
                     if edesc.error_code != DOCUMENT_ALREADY_EXISTS_API_ERROR_CODE
                     if edesc.message
+                ]
+                all_err_descs = "; ".join(
+                    edesc.message or ""
+                    for edesc in filtered_error_descs[:MAX_SHOWN_INSERTION_ERRORS]
                 )
+                there_s_more: str
+                if len(filtered_error_descs) > MAX_SHOWN_INSERTION_ERRORS:
+                    num_residual = (
+                        len(filtered_error_descs) - MAX_SHOWN_INSERTION_ERRORS
+                    )
+                    there_s_more = f". (Note: {num_residual} further errors omitted.)"
+                else:
+                    there_s_more = ""
                 full_err_message = (
                     "Cannot insert documents. The Data API returned the "
-                    f"following error(s): {all_err_descs}"
+                    f"following error(s): {all_err_descs}{there_s_more}"
                 )
                 raise ValueError(full_err_message) from err
 

--- a/libs/astradb/langchain_astradb/vectorstores.py
+++ b/libs/astradb/langchain_astradb/vectorstores.py
@@ -1062,7 +1062,20 @@ class AstraDBVectorStore(VectorStore):
                     if document["_id"] not in inserted_ids_set
                 ]
             else:
-                raise
+                # Raise a non-astrapy error with a message covering all errors
+                # except the DOCUMENT_ALREADY_EXISTS_API_ERROR_CODE, which this
+                # method can handle (if they were the only error)
+                all_err_descs = "; ".join(
+                    edesc.message
+                    for edesc in err.error_descriptors
+                    if edesc.error_code != DOCUMENT_ALREADY_EXISTS_API_ERROR_CODE
+                    if edesc.message
+                )
+                full_err_message = (
+                    "Cannot insert documents. The Data API returned the "
+                    f"following error(s): {all_err_descs}"
+                )
+                raise ValueError(full_err_message) from err
 
         # if necessary, replace docs for the non-inserted ids
         if ids_to_replace:
@@ -1191,7 +1204,20 @@ class AstraDBVectorStore(VectorStore):
                     if document["_id"] not in inserted_ids_set
                 ]
             else:
-                raise
+                # Raise a non-astrapy error with a message covering all errors
+                # except the DOCUMENT_ALREADY_EXISTS_API_ERROR_CODE, which this
+                # method can handle (if they were the only error)
+                all_err_descs = "; ".join(
+                    edesc.message
+                    for edesc in err.error_descriptors
+                    if edesc.error_code != DOCUMENT_ALREADY_EXISTS_API_ERROR_CODE
+                    if edesc.message
+                )
+                full_err_message = (
+                    "Cannot insert documents. The Data API returned the "
+                    f"following error(s): {all_err_descs}"
+                )
+                raise ValueError(full_err_message) from err
 
         # if necessary, replace docs for the non-inserted ids
         if ids_to_replace:

--- a/libs/astradb/tests/integration_tests/test_vectorstore_ddl_tests.py
+++ b/libs/astradb/tests/integration_tests/test_vectorstore_ddl_tests.py
@@ -11,7 +11,6 @@ from typing import TYPE_CHECKING
 
 import pytest
 from astrapy.authentication import EmbeddingAPIKeyHeaderProvider, StaticTokenProvider
-from astrapy.exceptions import InsertManyException
 
 from langchain_astradb.utils.astradb import SetupMode
 from langchain_astradb.vectorstores import AstraDBVectorStore
@@ -510,7 +509,7 @@ class TestAstraDBVectorStoreDDLs:
         )
         # More specific messages are provider-specific, such as OpenAI returning:
         # "... Incorrect API key provided: verywrong ..."
-        with pytest.raises(InsertManyException, match="Embedding Provider returned"):
+        with pytest.raises(ValueError, match="Embedding Provider returned"):
             v_store.add_texts(["Failing"])
 
     @pytest.mark.skipif(
@@ -538,5 +537,5 @@ class TestAstraDBVectorStoreDDLs:
         )
         # More specific messages are provider-specific, such as OpenAI returning:
         # "... Incorrect API key provided: verywrong ..."
-        with pytest.raises(InsertManyException, match="Embedding Provider returned"):
+        with pytest.raises(ValueError, match="Embedding Provider returned"):
             v_store.add_texts(["Failing"])

--- a/libs/astradb/tests/integration_tests/test_vectorstore_ddl_tests.py
+++ b/libs/astradb/tests/integration_tests/test_vectorstore_ddl_tests.py
@@ -13,7 +13,7 @@ import pytest
 from astrapy.authentication import EmbeddingAPIKeyHeaderProvider, StaticTokenProvider
 
 from langchain_astradb.utils.astradb import SetupMode
-from langchain_astradb.vectorstores import AstraDBVectorStore
+from langchain_astradb.vectorstores import AstraDBVectorStore, AstraDBVectorStoreError
 
 from .conftest import (
     EPHEMERAL_CUSTOM_IDX_NAME_D2,
@@ -509,7 +509,7 @@ class TestAstraDBVectorStoreDDLs:
         )
         # More specific messages are provider-specific, such as OpenAI returning:
         # "... Incorrect API key provided: verywrong ..."
-        with pytest.raises(ValueError, match="Embedding Provider returned"):
+        with pytest.raises(AstraDBVectorStoreError, match="verywrong"):
             v_store.add_texts(["Failing"])
 
     @pytest.mark.skipif(
@@ -537,5 +537,5 @@ class TestAstraDBVectorStoreDDLs:
         )
         # More specific messages are provider-specific, such as OpenAI returning:
         # "... Incorrect API key provided: verywrong ..."
-        with pytest.raises(ValueError, match="Embedding Provider returned"):
+        with pytest.raises(AstraDBVectorStoreError, match="verywrong"):
             v_store.add_texts(["Failing"])

--- a/libs/astradb/tests/unit_tests/test_imports.py
+++ b/libs/astradb/tests/unit_tests/test_imports.py
@@ -9,6 +9,7 @@ EXPECTED_ALL = [
     "AstraDBGraphVectorStore",
     "AstraDBLoader",
     "AstraDBVectorStore",
+    "AstraDBVectorStoreError",
     "CollectionVectorServiceOptions",
 ]
 


### PR DESCRIPTION
This PR alleviates a problem with the kind of error that is raised under different failure scenarios during AstraDBVectorStore insertions.

~(Do not mind the CI failing. There is some bug with the CI actions related to secrets not trickling down to the test workflows. I ran the tests locally and everything related went smooth.)~ <== Nevermind, those CI problems somehow have vanished (by themselves?).

### Current problems:

the insertion is attempted assuming new document _ids. If it fails, the (detailed) errors from astrapy are inspected.
(note: "errors", plural, since a single insertion can result in a number of errors from several documents).

1. If they are all of type "id already exists", then the flow switches to running a bunch of find-one-and-update and everything works
2. if there are (also) other errors from the Data API, an exception is surfaced to the user.

Now, this exception right now is the one received from Astrapy, a fact which has two flaws:

- It includes the "doc already exists" bits (that the V.Store in reality could handle if they were the only problem)
- Its string representation, in astrapy 1.x, just lists the first of the possibly many errors. (this is fixed in astrapy 2.0 but that's another story)

These 2 issues can combine leading to a scenario where all the user sees is a "doc already exists", adding to the confusion.

Also it can be argued that it is leaky, in this case, to expose an astrapy exception as is to the user.

### What this PR does

The change is for case 2 above.

- Now a ~ValueError~ newly-introduced `langchain_astradb.AstraDBVectorStoreError` is raised (and not a `astrapy.exception.InsertManyException` anymore - **slightly breaking for try-catch code**)
- The text message of this error is a concatenation of all errors from the Data API triggered by the insertion, with the "already exists" filtered out. _In case there are too many, a max amount is shown with a "there is more" notice.
- The original astrapy exception is always chained, so if users want to dig deeper they can inspect the error's `__cause__`. A note in the very error messages reminds the user about this (see examples below).

Below is a Python script exemplifying various insertion scenarios and the before- and after- kind of exception a user would get.

## Demo script (before-and-after)

```python
"""
This script demonstrates the changes this PR brings to the insertion exception logic.

The vectorstore starts empty and then runs 5 add_documents calls, with
new-id and preexisting-id, with faulty documents thrown in, as shown in the diagram
a few lines below.

For the relevant insertions, the class and message of the exception
is given in comments in this code.

I think this change fixes the shortcomings about
truncated/irrelevant error messages.

A question remains: shall the all-error description be given an upper limit to the number
of errors it concatenates (20 or so) ? It could become a *really* long string otherwise
(and if the insertion fails 20+ times, there's probably little point in notifying the user
about all of them...)
"""

import json
import os

from langchain_core.documents import Document
from langchain_core.embeddings import Embeddings

from langchain_astradb import AstraDBVectorStore


class ParserEmbeddings(Embeddings):
    """Parse input texts: if they are json for a List[float], fine.
    Otherwise, return all zeros and call it a day.
    """

    def __init__(self, dimension: int) -> None:
        self.dimension = dimension

    def embed_documents(self, texts: list[str]) -> list[list[float]]:
        return [self.embed_query(txt) for txt in texts]

    async def aembed_documents(self, texts: list[str]) -> list[list[float]]:
        return self.embed_documents(texts)

    def embed_query(self, text: str) -> list[float]:
        try:
            vals = json.loads(text)
        except json.JSONDecodeError:
            return [0.0] * self.dimension
        else:
            assert len(vals) == self.dimension
            return vals

    async def aembed_query(self, text: str) -> list[float]:
        return self.embed_query(text)


"""
Insertion rounds, plan:

_id    A     B     C     D     E
 00    I     .     .     .     .
 01    I     .     .     .     .
 02    I     .     .     .     .
 03    I     .     .     .     .
 04    I     .     .     .     .
 05    I     O     .     .     .
 06    I     O     .     .     .
 07    I     O     .     .     .
 08    I     O     .     .     .
 09    I     O     .     .     .
 10    .     I     .     .     .
 11    .     I     .     .     .
 12    .     I     .     .     .
 13    .     I     .     .     .
 14    .     I     O     .     .
 15    .     .     F     .     .
 16    .     .     I     .     .
 17    .     .     I     .     .
 18    .     .     I     .     .
 19    .     .     I     .     .
 20    .     .     I     F     .
 21    .     .     I     F     .
 22    .     .     I     .     F
 23    .     .     I     .     .
 24    .     .     I     .     .

    I = insert
    O = overwrite (insert on preexisting ID)
    F = faulty doc supplied
"""

if __name__ == "__main__":
    embe = ParserEmbeddings(2)

    vstore = AstraDBVectorStore(
        collection_name="errmessages",
        embedding=embe,
        token=os.environ["ASTRA_DB_APPLICATION_TOKEN"],
        api_endpoint=os.environ["ASTRA_DB_API_ENDPOINT"],
        batch_size=5,
    )
    vstore.clear()

    # A: insertion ok
    vstore.add_documents(
        [
            Document(
                page_content=f"[1,{di}]", metadata={"a": di, "gen": "A"}, id=f"{di:02}"
            )
            for di in range(10)
        ]
    )

    # B: insertion with dupes
    vstore.add_documents(
        [
            Document(
                page_content=f"[1,{di}]", metadata={"a": di, "gen": "B"}, id=f"{di:02}"
            )
            for di in range(5, 15)
        ]
    )

    # C: insertion with mixed errors
    try:
        vstore.add_documents(
            [
                # a puny overwrite
                Document(
                    page_content="[1,14]", metadata={"a": 14, "gen": "C"}, id="14"
                ),
            ]
            + [
                # new ones - but with a faulty doc in the middle
                Document(
                    page_content="[1,15]", metadata={"a": 15, "gen": "C"}, id="15"
                ),
                Document(
                    page_content="[1,16]",
                    metadata={"a": 16, "gen": "C", "$trouble?": "yes"},
                    id="16",
                ),
            ]
            + [
                Document(
                    page_content=f"[1,{di}]",
                    metadata={"a": di, "gen": "C"},
                    id=f"{di:02}",
                )
                for di in range(17, 25)
            ]
        )
    except Exception as err:
        print("\nC => ERROR")
        print(f"    str(err):  {str(err)}")
        print(f"    type(err): {type(err)}")
        print(f"    err:       {err}")
        print(f"    C.ERRDSC:  {err.__cause__.error_descriptors}")

    """
    Current output is incomplete and misleading.
    (the mentioned _id does not get overwritten in the collection, but the faulty one is not reported!)

        C => ERROR
            str(err):  Failed to insert document with _id 14: Document already exists with the given _id
            type(err): <class 'astrapy.exceptions.InsertManyException'>
            err:       Failed to insert document with _id 14: Document already exists with the given _id

    This PR:

        C => ERROR
            str(err):  Cannot insert documents. The Data API returned the following error(s): Failed to insert document with _id 16: Document field name invalid: field name ('$trouble?') contains invalid character(s), can contain only letters (a-z/A-Z), numbers (0-9), underscores (_), and hyphens (-) (Full API error in '<this-exception>.__cause__.error_descriptors': ignore 'DOCUMENT_ALREADY_EXISTS'.)
            type(err): <class 'langchain_astradb.vectorstores.AstraDBVectorStoreError'>
            err:       Cannot insert documents. The Data API returned the following error(s): Failed to insert document with _id 16: Document field name invalid: field name ('$trouble?') contains invalid character(s), can contain only letters (a-z/A-Z), numbers (0-9), underscores (_), and hyphens (-) (Full API error in '<this-exception>.__cause__.error_descriptors': ignore 'DOCUMENT_ALREADY_EXISTS'.)
            C.ERRDSC:  [DataAPIErrorDescriptor('Document already exists with the given _id', error_code='DOCUMENT_ALREADY_EXISTS', message='Failed to insert document with _id 14: Document already exists with the given _id', family='REQUEST', scope='DOCUMENT', id='34761ccd-8d6d-45fd-801a-bcad74bcc201'), DataAPIErrorDescriptor('Document field name invalid', error_code='SHRED_DOC_KEY_NAME_VIOLATION', message="Failed to insert document with _id 16: Document field name invalid: field name ('$trouble?') contains invalid character(s), can contain only letters (a-z/A-Z), numbers (0-9), underscores (_), and hyphens (-)", family='REQUEST', scope='DOCUMENT', id='a893ec7f-8eb0-4c3d-a26c-d558e7ff9128')]
    """

    # D: insertion with only errors
    try:
        vstore.add_documents(
            [
                Document(
                    page_content="[1,20]",
                    metadata={"a": 20, "gen": "D", "$trouble?": "yes"},
                    id="20",
                ),
                Document(
                    page_content="[1,21]",
                    metadata={"a": 21, "gen": "D", "superlist": list(range(1001))},
                    id="21",
                ),
            ]
            + [
                Document(
                    page_content=f"[1,{i}]",
                    metadata={"a": i, "gen": "D", "$trouble?": "yes"},
                    id=f"{i:02}",
                )
                for i in range(50, 60)
            ]
        )
    except Exception as err:
        print("\nD => ERROR")
        print(f"    str(err):  {str(err)}")
        print(f"    type(err): {type(err)}")
        print(f"    err:       {err}")
        print(f"    C.ERRDSC:  {err.__cause__.error_descriptors}")
    """
    Current output is incomplete: only the first error is mentioned.

        D => ERROR
            str(err):  Failed to insert document with _id 20: Document field name invalid: field name ('$trouble?') contains invalid character(s), can contain only letters (a-z/A-Z), numbers (0-9), underscores (_), and hyphens (-)
            type(err): <class 'astrapy.exceptions.InsertManyException'>
            err:       Failed to insert document with _id 20: Document field name invalid: field name ('$trouble?') contains invalid character(s), can contain only letters (a-z/A-Z), numbers (0-9), underscores (_), and hyphens (-)

    This PR:

        D => ERROR
            str(err):  Cannot insert documents. The Data API returned the following error(s): Failed to insert document with _id 20: Document field name invalid: field name ('$trouble?') contains invalid character(s), can contain only letters (a-z/A-Z), numbers (0-9), underscores (_), and hyphens (-); Failed to insert document with _id 21: Document size limitation violated: number of elements an indexable Array (property 'superlist') has (1001) exceeds maximum allowed (1000); Failed to insert document with _id 50: Document field name invalid: field name ('$trouble?') contains invalid character(s), can contain only letters (a-z/A-Z), numbers (0-9), underscores (_), and hyphens (-); Failed to insert document with _id 51: Document field name invalid: field name ('$trouble?') contains invalid character(s), can contain only letters (a-z/A-Z), numbers (0-9), underscores (_), and hyphens (-); Failed to insert document with _id 52: Document field name invalid: field name ('$trouble?') contains invalid character(s), can contain only letters (a-z/A-Z), numbers (0-9), underscores (_), and hyphens (-); Failed to insert document with _id 53: Document field name invalid: field name ('$trouble?') contains invalid character(s), can contain only letters (a-z/A-Z), numbers (0-9), underscores (_), and hyphens (-); Failed to insert document with _id 54: Document field name invalid: field name ('$trouble?') contains invalid character(s), can contain only letters (a-z/A-Z), numbers (0-9), underscores (_), and hyphens (-); Failed to insert document with _id 55: Document field name invalid: field name ('$trouble?') contains invalid character(s), can contain only letters (a-z/A-Z), numbers (0-9), underscores (_), and hyphens (-). (Note: 4 further errors omitted.) (Full API error in '<this-exception>.__cause__.error_descriptors': ignore 'DOCUMENT_ALREADY_EXISTS'.)
            type(err): <class 'langchain_astradb.vectorstores.AstraDBVectorStoreError'>
            err:       Cannot insert documents. The Data API returned the following error(s): Failed to insert document with _id 20: Document field name invalid: field name ('$trouble?') contains invalid character(s), can contain only letters (a-z/A-Z), numbers (0-9), underscores (_), and hyphens (-); Failed to insert document with _id 21: Document size limitation violated: number of elements an indexable Array (property 'superlist') has (1001) exceeds maximum allowed (1000); Failed to insert document with _id 50: Document field name invalid: field name ('$trouble?') contains invalid character(s), can contain only letters (a-z/A-Z), numbers (0-9), underscores (_), and hyphens (-); Failed to insert document with _id 51: Document field name invalid: field name ('$trouble?') contains invalid character(s), can contain only letters (a-z/A-Z), numbers (0-9), underscores (_), and hyphens (-); Failed to insert document with _id 52: Document field name invalid: field name ('$trouble?') contains invalid character(s), can contain only letters (a-z/A-Z), numbers (0-9), underscores (_), and hyphens (-); Failed to insert document with _id 53: Document field name invalid: field name ('$trouble?') contains invalid character(s), can contain only letters (a-z/A-Z), numbers (0-9), underscores (_), and hyphens (-); Failed to insert document with _id 54: Document field name invalid: field name ('$trouble?') contains invalid character(s), can contain only letters (a-z/A-Z), numbers (0-9), underscores (_), and hyphens (-); Failed to insert document with _id 55: Document field name invalid: field name ('$trouble?') contains invalid character(s), can contain only letters (a-z/A-Z), numbers (0-9), underscores (_), and hyphens (-). (Note: 4 further errors omitted.) (Full API error in '<this-exception>.__cause__.error_descriptors': ignore 'DOCUMENT_ALREADY_EXISTS'.)
            C.ERRDSC:  [DataAPIErrorDescriptor('Document field name invalid', error_code='SHRED_DOC_KEY_NAME_VIOLATION', message="Failed to insert document with _id 20: Document field name invalid: field name ('$trouble?') contains invalid character(s), can contain only letters (a-z/A-Z), numbers (0-9), underscores (_), and hyphens (-)", family='REQUEST', scope='DOCUMENT', id='6bc3df55-7fb7-448d-ac48-b351715ffbdf'), DataAPIErrorDescriptor('Document size limitation violated', error_code='SHRED_DOC_LIMIT_VIOLATION', message="Failed to insert document with _id 21: Document size limitation violated: number of elements an indexable Array (property 'superlist') has (1001) exceeds maximum allowed (1000)", family='REQUEST', scope='DOCUMENT', id='ba8aa416-262c-4fe9-b6a5-19c912c4f9f5'), DataAPIErrorDescriptor('Document field name invalid', error_code='SHRED_DOC_KEY_NAME_VIOLATION', message="Failed to insert document with _id 50: Document field name invalid: field name ('$trouble?') contains invalid character(s), can contain only letters (a-z/A-Z), numbers (0-9), underscores (_), and hyphens (-)", family='REQUEST', scope='DOCUMENT', id='58aa4d9b-ae65-4b29-be69-a6d546f9b2e4'), DataAPIErrorDescriptor('Document field name invalid', error_code='SHRED_DOC_KEY_NAME_VIOLATION', message="Failed to insert document with _id 51: Document field name invalid: field name ('$trouble?') contains invalid character(s), can contain only letters (a-z/A-Z), numbers (0-9), underscores (_), and hyphens (-)", family='REQUEST', scope='DOCUMENT', id='f4b323b2-9189-4a5e-9122-3d0e7925fcd9'), DataAPIErrorDescriptor('Document field name invalid', error_code='SHRED_DOC_KEY_NAME_VIOLATION', message="Failed to insert document with _id 52: Document field name invalid: field name ('$trouble?') contains invalid character(s), can contain only letters (a-z/A-Z), numbers (0-9), underscores (_), and hyphens (-)", family='REQUEST', scope='DOCUMENT', id='891159be-0e6f-4e0b-9770-3546565f5321'), DataAPIErrorDescriptor('Document field name invalid', error_code='SHRED_DOC_KEY_NAME_VIOLATION', message="Failed to insert document with _id 53: Document field name invalid: field name ('$trouble?') contains invalid character(s), can contain only letters (a-z/A-Z), numbers (0-9), underscores (_), and hyphens (-)", family='REQUEST', scope='DOCUMENT', id='1c399a2c-9193-4b8f-a14c-b4d32a5e67f6'), DataAPIErrorDescriptor('Document field name invalid', error_code='SHRED_DOC_KEY_NAME_VIOLATION', message="Failed to insert document with _id 54: Document field name invalid: field name ('$trouble?') contains invalid character(s), can contain only letters (a-z/A-Z), numbers (0-9), underscores (_), and hyphens (-)", family='REQUEST', scope='DOCUMENT', id='21921de2-f710-4d0a-ac1a-2f35456397b6'), DataAPIErrorDescriptor('Document field name invalid', error_code='SHRED_DOC_KEY_NAME_VIOLATION', message="Failed to insert document with _id 55: Document field name invalid: field name ('$trouble?') contains invalid character(s), can contain only letters (a-z/A-Z), numbers (0-9), underscores (_), and hyphens (-)", family='REQUEST', scope='DOCUMENT', id='033b981f-2649-4464-95df-152e169cbe76'), DataAPIErrorDescriptor('Document field name invalid', error_code='SHRED_DOC_KEY_NAME_VIOLATION', message="Failed to insert document with _id 56: Document field name invalid: field name ('$trouble?') contains invalid character(s), can contain only letters (a-z/A-Z), numbers (0-9), underscores (_), and hyphens (-)", family='REQUEST', scope='DOCUMENT', id='a4372af9-0170-41d7-a4bc-10ddd9a1139d'), DataAPIErrorDescriptor('Document field name invalid', error_code='SHRED_DOC_KEY_NAME_VIOLATION', message="Failed to insert document with _id 57: Document field name invalid: field name ('$trouble?') contains invalid character(s), can contain only letters (a-z/A-Z), numbers (0-9), underscores (_), and hyphens (-)", family='REQUEST', scope='DOCUMENT', id='5775d759-43f3-4ef1-ad24-68dfee39ad11'), DataAPIErrorDescriptor('Document field name invalid', error_code='SHRED_DOC_KEY_NAME_VIOLATION', message="Failed to insert document with _id 58: Document field name invalid: field name ('$trouble?') contains invalid character(s), can contain only letters (a-z/A-Z), numbers (0-9), underscores (_), and hyphens (-)", family='REQUEST', scope='DOCUMENT', id='c0825e68-84fe-4fd5-b562-62e8dc07e192'), DataAPIErrorDescriptor('Document field name invalid', error_code='SHRED_DOC_KEY_NAME_VIOLATION', message="Failed to insert document with _id 59: Document field name invalid: field name ('$trouble?') contains invalid character(s), can contain only letters (a-z/A-Z), numbers (0-9), underscores (_), and hyphens (-)", family='REQUEST', scope='DOCUMENT', id='c7af12d7-27c4-4ece-92f8-825983d2a43b')]
    """

    # E: *single* insertion with an error
    try:
        vstore.add_documents(
            [
                Document(
                    page_content="[1,22]",
                    metadata={"a": 22, "gen": "D", "$trouble?": "yes"},
                    id="22",
                ),
            ]
        )
    except Exception as err:
        print("\nE => ERROR")
        print(f"    str(err):  {str(err)}")
        print(f"    type(err): {type(err)}")
        print(f"    err:       {err}")
        print(f"    C.ERRDSC:  {err.__cause__.error_descriptors}")
    """
    Current output is lacking the 'failed to insert document with id' preamble:

        E => ERROR
            str(err):  Document field name invalid: field name ('$trouble?') contains invalid character(s), can contain only letters (a-z/A-Z), numbers (0-9), underscores (_), and hyphens (-)
            type(err): <class 'astrapy.exceptions.InsertManyException'>
            err:       Document field name invalid: field name ('$trouble?') contains invalid character(s), can contain only letters (a-z/A-Z), numbers (0-9), underscores (_), and hyphens (-)

    **NOTE**: The lack of _id in this case is a Data API behaviour (filed an issue: https://github.com/stargate/data-api/issues/1840). Should not ever be a real problem in this context.

    This PR:

        E => ERROR
            str(err):  Cannot insert documents. The Data API returned the following error(s): Document field name invalid: field name ('$trouble?') contains invalid character(s), can contain only letters (a-z/A-Z), numbers (0-9), underscores (_), and hyphens (-) (Full API error in '<this-exception>.__cause__.error_descriptors': ignore 'DOCUMENT_ALREADY_EXISTS'.)
            type(err): <class 'langchain_astradb.vectorstores.AstraDBVectorStoreError'>
            err:       Cannot insert documents. The Data API returned the following error(s): Document field name invalid: field name ('$trouble?') contains invalid character(s), can contain only letters (a-z/A-Z), numbers (0-9), underscores (_), and hyphens (-) (Full API error in '<this-exception>.__cause__.error_descriptors': ignore 'DOCUMENT_ALREADY_EXISTS'.)
            C.ERRDSC:  [DataAPIErrorDescriptor('Document field name invalid', error_code='SHRED_DOC_KEY_NAME_VIOLATION', message="Document field name invalid: field name ('$trouble?') contains invalid character(s), can contain only letters (a-z/A-Z), numbers (0-9), underscores (_), and hyphens (-)", family='REQUEST', scope='DOCUMENT', id='8685b9ae-c5f3-445c-9c7d-5fea3ab4f6fd')]
    """
```