### PR TITLE
Add "with_component_name" method to AstraDBVectorStore

### DIFF
--- a/libs/astradb/langchain_astradb/vectorstores.py
+++ b/libs/astradb/langchain_astradb/vectorstores.py
@@ -21,7 +21,9 @@ from typing import (
 )
 
 import numpy as np
+from astrapy.constants import Environment
 from astrapy.exceptions import InsertManyException
+from astrapy.info import CollectionVectorServiceOptions
 from langchain_community.vectorstores.utils import maximal_marginal_relevance
 from langchain_core.runnables.utils import gather_with_concurrency
 from langchain_core.vectorstores import VectorStore
@@ -54,7 +56,6 @@ if TYPE_CHECKING:
     from astrapy.db import (
         AsyncAstraDB as AsyncAstraDBClient,
     )
-    from astrapy.info import CollectionVectorServiceOptions
     from astrapy.results import UpdateResult
     from langchain_core.documents import Document
     from langchain_core.embeddings import Embeddings
@@ -722,6 +723,45 @@ class AstraDBVectorStore(VectorStore):
         # i.e. one in [0, 1] where higher means more *similar*,
         # so here the final score transformation is not reversing the interval.
         return lambda score: score
+
+    def with_component_name(self, component_name: str) -> AstraDBVectorStore:
+        """Create a copy of this vector store with just the 'component name' changed.
+
+        Attributes:
+            component_name: the new value, which replaces the current one in the copy.
+        """
+        copy = AstraDBVectorStore(
+            collection_name="moot",
+            api_endpoint="http://moot",
+            environment=Environment.OTHER,
+            namespace="moot",
+            setup_mode=SetupMode.OFF,
+            collection_vector_service_options=CollectionVectorServiceOptions(
+                provider="moot",
+                model_name="moot",
+            ),
+        )
+        copy.collection_name = self.collection_name
+        copy.token = self.token
+        copy.api_endpoint = self.api_endpoint
+        copy.environment = self.environment
+        copy.namespace = self.namespace
+        copy.indexing_policy = self.indexing_policy
+        copy.autodetect_collection = self.autodetect_collection
+        copy.embedding_dimension = self.embedding_dimension
+        copy.embedding = self.embedding
+        copy.metric = self.metric
+        copy.collection_embedding_api_key = self.collection_embedding_api_key
+        copy.collection_vector_service_options = self.collection_vector_service_options
+        copy.document_codec = self.document_codec
+        copy.batch_size = self.batch_size
+        copy.bulk_insert_batch_concurrency = self.bulk_insert_batch_concurrency
+        copy.bulk_insert_overwrite_concurrency = self.bulk_insert_overwrite_concurrency
+        copy.bulk_delete_concurrency = self.bulk_delete_concurrency
+        # Now the .astra_env attribute:
+        copy.astra_env = self.astra_env.with_component_name(component_name)
+
+        return copy
 
     def clear(self) -> None:
         """Empty the collection of all its stored entries."""

--- a/libs/astradb/tests/unit_tests/test_callers.py
+++ b/libs/astradb/tests/unit_tests/test_callers.py
@@ -298,7 +298,7 @@ class TestCallers:
         self, httpserver: HTTPServer
     ) -> None:
         """
-        Test of "with_component_name" for the vectorstore.
+        Test of "with_component_name" for the vectorstore, checking the actual headers.
         """
         base_endpoint = httpserver.url_for("/")
         base_path = "/v1/ks"


### PR DESCRIPTION
This method returns a copy of the vector store with all properties unchanged except the caller information (used for usage stats by Astra DB's Data API), where the "component name" is replaced by a new supplied value.

This is needed by the implementation of Graph Vector Store as a Retriever delegating to the vector store class.

The method does instantiate a new AstraDBVectorStore with dummy values and SetupMode=OFF to avoid triggering any actual work, then proceeds to replace all "private" members of the new instance to make it an exact copy, save for the "component name". This has required a similar logic to be coded into the AstraDBEnvironment/CollectionEnvironment as well.
(The alternative of making room in the constructor for such a path was deemed too consequence-bearing to be pursued.)

