### PR TITLE
Vector Store, full separation codec / vectorstore

### DIFF
--- a/libs/astradb/langchain_astradb/utils/vector_store_codecs.py
+++ b/libs/astradb/langchain_astradb/utils/vector_store_codecs.py
@@ -46,6 +46,12 @@ def _default_encode_id(filter_id: str) -> dict[str, Any]:
     return {"_id": filter_id}
 
 
+def _default_encode_ids(filter_ids: list[str]) -> dict[str, Any]:
+    if len(filter_ids) == 1:
+        return _default_encode_id(filter_ids[0])
+    return {"_id": {"$in": filter_ids}}
+
+
 def _default_encode_vector_sort(vector: list[float]) -> dict[str, Any]:
     return {"$vector": vector}
 
@@ -131,7 +137,6 @@ class _AstraDBVectorStoreDocumentCodec(ABC):
             an equivalent filter clause for use in Astra DB's find queries.
         """
 
-    @abstractmethod
     def encode_id(self, filter_id: str) -> dict[str, Any]:
         """Encode an ID as a filter for use in Astra DB queries.
 
@@ -139,10 +144,23 @@ class _AstraDBVectorStoreDocumentCodec(ABC):
             filter_id: the ID value to filter on.
 
         Returns:
-            an filter clause for use in Astra DB's find queries.
+            a filter clause for use in Astra DB's find queries.
         """
+        return _default_encode_id(filter_id)
 
-    @abstractmethod
+    def encode_ids(self, filter_ids: list[str]) -> dict[str, Any]:
+        """Encode a list of IDs as an appropriate search filter.
+
+        The resulting filter expresses condition: "document ID is among filter_ids".
+
+        Args:
+            filter_ids: the ID values to filter on.
+
+        Returns:
+            a filter clause for use in Astra DB's find queries.
+        """
+        return _default_encode_ids(filter_ids)
+
     def encode_vector_sort(self, vector: list[float]) -> dict[str, Any]:
         """Encode a vector as a sort to use for Astra DB queries.
 
@@ -152,6 +170,7 @@ class _AstraDBVectorStoreDocumentCodec(ABC):
         Returns:
             an order clause for use in Astra DB's find queries.
         """
+        return _default_encode_vector_sort(vector)
 
 
 class _DefaultVSDocumentCodec(_AstraDBVectorStoreDocumentCodec):
@@ -224,14 +243,6 @@ class _DefaultVSDocumentCodec(_AstraDBVectorStoreDocumentCodec):
     @override
     def encode_filter(self, filter_dict: dict[str, Any]) -> dict[str, Any]:
         return _default_encode_filter(filter_dict)
-
-    @override
-    def encode_id(self, filter_id: str) -> dict[str, Any]:
-        return _default_encode_id(filter_id)
-
-    @override
-    def encode_vector_sort(self, vector: list[float]) -> dict[str, Any]:
-        return _default_encode_vector_sort(vector)
 
 
 class _DefaultVectorizeVSDocumentCodec(_AstraDBVectorStoreDocumentCodec):
@@ -307,14 +318,6 @@ class _DefaultVectorizeVSDocumentCodec(_AstraDBVectorStoreDocumentCodec):
     @override
     def encode_filter(self, filter_dict: dict[str, Any]) -> dict[str, Any]:
         return _default_encode_filter(filter_dict)
-
-    @override
-    def encode_id(self, filter_id: str) -> dict[str, Any]:
-        return _default_encode_id(filter_id)
-
-    @override
-    def encode_vector_sort(self, vector: list[float]) -> dict[str, Any]:
-        return _default_encode_vector_sort(vector)
 
 
 class _FlatVSDocumentCodec(_AstraDBVectorStoreDocumentCodec):
@@ -396,14 +399,6 @@ class _FlatVSDocumentCodec(_AstraDBVectorStoreDocumentCodec):
     def encode_filter(self, filter_dict: dict[str, Any]) -> dict[str, Any]:
         return filter_dict
 
-    @override
-    def encode_id(self, filter_id: str) -> dict[str, Any]:
-        return _default_encode_id(filter_id)
-
-    @override
-    def encode_vector_sort(self, vector: list[float]) -> dict[str, Any]:
-        return _default_encode_vector_sort(vector)
-
 
 class _FlatVectorizeVSDocumentCodec(_AstraDBVectorStoreDocumentCodec):
     """Codec for collections populated externally, with server-side embeddings.
@@ -476,11 +471,3 @@ class _FlatVectorizeVSDocumentCodec(_AstraDBVectorStoreDocumentCodec):
     @override
     def encode_filter(self, filter_dict: dict[str, Any]) -> dict[str, Any]:
         return filter_dict
-
-    @override
-    def encode_id(self, filter_id: str) -> dict[str, Any]:
-        return _default_encode_id(filter_id)
-
-    @override
-    def encode_vector_sort(self, vector: list[float]) -> dict[str, Any]:
-        return _default_encode_vector_sort(vector)

--- a/libs/astradb/langchain_astradb/vectorstores.py
+++ b/libs/astradb/langchain_astradb/vectorstores.py
@@ -869,7 +869,7 @@ class AstraDBVectorStore(VectorStore):
         self.astra_env.ensure_db_setup()
         # self.collection is not None (by _ensure_astra_db_client)
         deletion_response = self.astra_env.collection.delete_one(
-            self.document_codec.encode_id(document_id),
+            self.document_codec.encode_query(ids=[document_id]),
         )
         return deletion_response.deleted_count == 1
 
@@ -884,7 +884,7 @@ class AstraDBVectorStore(VectorStore):
         """
         await self.astra_env.aensure_db_setup()
         deletion_response = await self.astra_env.async_collection.delete_one(
-            self.document_codec.encode_id(document_id),
+            self.document_codec.encode_query(ids=[document_id]),
         )
         return deletion_response.deleted_count == 1
 
@@ -1183,7 +1183,7 @@ class AstraDBVectorStore(VectorStore):
                 ) -> tuple[UpdateResult, str]:
                     doc_id = self.document_codec.get_id(document)
                     return self.astra_env.collection.replace_one(
-                        self.document_codec.encode_id(doc_id),
+                        self.document_codec.encode_query(ids=[doc_id]),
                         document,
                     ), doc_id
 
@@ -1315,7 +1315,7 @@ class AstraDBVectorStore(VectorStore):
                 async with sem:
                     doc_id = self.document_codec.get_id(document)
                     return await _async_collection.replace_one(
-                        self.document_codec.encode_id(doc_id),
+                        self.document_codec.encode_query(ids=[doc_id]),
                         document,
                     ), doc_id
 
@@ -1376,7 +1376,7 @@ class AstraDBVectorStore(VectorStore):
                 document_id, update_metadata = id_md_pair
                 encoded_metadata = self.filter_to_query(update_metadata)
                 return self.astra_env.collection.update_one(
-                    self.document_codec.encode_id(document_id),
+                    self.document_codec.encode_query(ids=[document_id]),
                     {"$set": encoded_metadata},
                 )
 
@@ -1429,7 +1429,7 @@ class AstraDBVectorStore(VectorStore):
             encoded_metadata = self.filter_to_query(update_metadata)
             async with sem:
                 return await _async_collection.update_one(
-                    self.document_codec.encode_id(document_id),
+                    self.document_codec.encode_query(ids=[document_id]),
                     {"$set": encoded_metadata},
                 )
 
@@ -1501,7 +1501,7 @@ class AstraDBVectorStore(VectorStore):
         self.astra_env.ensure_db_setup()
         # self.collection is not None (by _ensure_astra_db_client)
         hit = self.astra_env.collection.find_one(
-            self.document_codec.encode_id(document_id),
+            self.document_codec.encode_query(ids=[document_id]),
             projection=self.document_codec.base_projection,
         )
         if hit is None:
@@ -1520,7 +1520,7 @@ class AstraDBVectorStore(VectorStore):
         await self.astra_env.aensure_db_setup()
         # self.collection is not None (by _ensure_astra_db_client)
         hit = await self.astra_env.async_collection.find_one(
-            self.document_codec.encode_id(document_id),
+            self.document_codec.encode_query(ids=[document_id]),
             projection=self.document_codec.base_projection,
         )
         if hit is None:

--- a/libs/astradb/tests/integration_tests/conftest.py
+++ b/libs/astradb/tests/integration_tests/conftest.py
@@ -32,7 +32,10 @@ from astrapy.db import AstraDB
 from astrapy.info import CollectionVectorServiceOptions
 
 from langchain_astradb.utils.astradb import SetupMode
-from langchain_astradb.vectorstores import DEFAULT_INDEXING_OPTIONS, AstraDBVectorStore
+from langchain_astradb.utils.vector_store_codecs import (
+    STANDARD_INDEXING_OPTIONS_DEFAULT,
+)
+from langchain_astradb.vectorstores import AstraDBVectorStore
 from tests.conftest import IdentityLLM, ParserEmbeddings
 
 if TYPE_CHECKING:
@@ -207,7 +210,7 @@ def collection_d2(
         COLLECTION_NAME_D2,
         dimension=2,
         check_exists=False,
-        indexing=DEFAULT_INDEXING_OPTIONS,
+        indexing=STANDARD_INDEXING_OPTIONS_DEFAULT,
         metric="euclidean",
     )
     yield collection
@@ -400,7 +403,7 @@ def collection_vz(
         COLLECTION_NAME_VZ,
         dimension=1536,
         check_exists=False,
-        indexing=DEFAULT_INDEXING_OPTIONS,
+        indexing=STANDARD_INDEXING_OPTIONS_DEFAULT,
         metric="euclidean",
         service=OPENAI_VECTORIZE_OPTIONS_HEADER,
         embedding_api_key=openai_api_key,

--- a/libs/astradb/tests/unit_tests/test_vs_doc_codecs.py
+++ b/libs/astradb/tests/unit_tests/test_vs_doc_codecs.py
@@ -9,6 +9,7 @@ from langchain_core.documents import Document
 from langchain_astradb.utils.vector_store_codecs import (
     NO_NULL_VECTOR_MSG,
     VECTOR_REQUIRED_PREAMBLE_MSG,
+    _AstraDBVectorStoreDocumentCodec,
     _DefaultVectorizeVSDocumentCodec,
     _DefaultVSDocumentCodec,
     _FlatVectorizeVSDocumentCodec,
@@ -21,7 +22,6 @@ VECTOR: list[float] = [1, 2, 3]
 DOCUMENT_ID = "the_id"
 LC_DOCUMENT = Document(id=DOCUMENT_ID, page_content=CONTENT, metadata=METADATA)
 LC_FILTER = {"a0": 0, "$or": [{"b1": 1}, {"b2": 2}]}
-ID_FILTER = {"_id": DOCUMENT_ID}
 VECTOR_SORT = {"$vector": VECTOR}
 
 ASTRA_DEFAULT_DOCUMENT_NOVECTORIZE = {
@@ -136,12 +136,86 @@ class TestVSDocCodecs:
         assert codec.decode_vector(ASTRA_DEFAULT_DOCUMENT_NOVECTORIZE) == VECTOR
         assert codec.decode_vector({}) is None
 
-    def test_default_novectorize_id_encoding(self) -> None:
-        """Test id-encoding for default, no-vectorize."""
-        codec = _DefaultVSDocumentCodec(
-            content_field="content_x", ignore_invalid_documents=False
-        )
-        assert codec.encode_id(DOCUMENT_ID) == ID_FILTER
+    @pytest.mark.parametrize(
+        ("default_codec_class", "codec_kwargs"),
+        [
+            (
+                _DefaultVSDocumentCodec,
+                {"content_field": "cf", "ignore_invalid_documents": False},
+            ),
+            (_DefaultVectorizeVSDocumentCodec, {"ignore_invalid_documents": False}),
+        ],
+        ids=("default", "default_vectorize"),
+    )
+    def test_default_query_encoding(
+        self,
+        default_codec_class: type[_AstraDBVectorStoreDocumentCodec],
+        codec_kwargs: dict[str, Any],
+    ) -> None:
+        """Test query-encoding for default, no-vectorize."""
+        codec = default_codec_class(**codec_kwargs)
+        assert codec.encode_query() == {}
+        assert codec.encode_query(ids=[DOCUMENT_ID]) == {"_id": DOCUMENT_ID}
+        assert codec.encode_query(ids=["id1", "id2"]) == {
+            "_id": {"$in": ["id1", "id2"]}
+        }
+        assert codec.encode_query(ids=[DOCUMENT_ID], filter_dict={"mdk": "mdv"}) == {
+            "$and": [{"_id": DOCUMENT_ID}, {"metadata.mdk": "mdv"}]
+        }
+        assert codec.encode_query(
+            ids=[DOCUMENT_ID], filter_dict={"mdk1": "mdv1", "mdk2": "mdv2"}
+        ) == {
+            "$and": [
+                {"_id": DOCUMENT_ID},
+                {"metadata.mdk1": "mdv1", "metadata.mdk2": "mdv2"},
+            ]
+        }
+        assert codec.encode_query(
+            ids=[DOCUMENT_ID], filter_dict={"$or": [{"mdk1": "mdv1"}, {"mdk2": "mdv2"}]}
+        ) == {
+            "$and": [
+                {"_id": DOCUMENT_ID},
+                {"$or": [{"metadata.mdk1": "mdv1"}, {"metadata.mdk2": "mdv2"}]},
+            ]
+        }
+
+    @pytest.mark.parametrize(
+        ("default_codec_class", "codec_kwargs"),
+        [
+            (
+                _FlatVSDocumentCodec,
+                {"content_field": "cf", "ignore_invalid_documents": False},
+            ),
+            (_FlatVectorizeVSDocumentCodec, {"ignore_invalid_documents": False}),
+        ],
+        ids=("flat", "flat_vectorize"),
+    )
+    def test_flat_query_encoding(
+        self,
+        default_codec_class: type[_AstraDBVectorStoreDocumentCodec],
+        codec_kwargs: dict[str, Any],
+    ) -> None:
+        """Test query-encoding for default, no-vectorize."""
+        codec = default_codec_class(**codec_kwargs)
+        assert codec.encode_query() == {}
+        assert codec.encode_query(ids=[DOCUMENT_ID]) == {"_id": DOCUMENT_ID}
+        assert codec.encode_query(ids=["id1", "id2"]) == {
+            "_id": {"$in": ["id1", "id2"]}
+        }
+        assert codec.encode_query(ids=[DOCUMENT_ID], filter_dict={"mdk": "mdv"}) == {
+            "$and": [{"_id": DOCUMENT_ID}, {"mdk": "mdv"}]
+        }
+        assert codec.encode_query(
+            ids=[DOCUMENT_ID], filter_dict={"mdk1": "mdv1", "mdk2": "mdv2"}
+        ) == {"$and": [{"_id": DOCUMENT_ID}, {"mdk1": "mdv1", "mdk2": "mdv2"}]}
+        assert codec.encode_query(
+            ids=[DOCUMENT_ID], filter_dict={"$or": [{"mdk1": "mdv1"}, {"mdk2": "mdv2"}]}
+        ) == {
+            "$and": [
+                {"_id": DOCUMENT_ID},
+                {"$or": [{"mdk1": "mdv1"}, {"mdk2": "mdv2"}]},
+            ]
+        }
 
     def test_default_novectorize_vectorsort_encoding(self) -> None:
         """Test vector-sort-encoding for default, no-vectorize."""
@@ -205,11 +279,6 @@ class TestVSDocCodecs:
         codec = _DefaultVectorizeVSDocumentCodec(ignore_invalid_documents=False)
         assert codec.decode_vector(ASTRA_DEFAULT_DOCUMENT_VECTORIZE_READ) == VECTOR
         assert codec.decode_vector({}) is None
-
-    def test_default_vectorize_id_encoding(self) -> None:
-        """Test id-encoding for default, vectorize."""
-        codec = _DefaultVectorizeVSDocumentCodec(ignore_invalid_documents=False)
-        assert codec.encode_id(DOCUMENT_ID) == ID_FILTER
 
     def test_default_vectorize_vectorsort_encoding(self) -> None:
         """Test vector-sort-encoding for default, vectorize."""
@@ -286,13 +355,6 @@ class TestVSDocCodecs:
         assert codec.decode_vector(ASTRA_FLAT_DOCUMENT_NOVECTORIZE) == VECTOR
         assert codec.decode_vector({}) is None
 
-    def test_flat_novectorize_id_encoding(self) -> None:
-        """Test id-encoding for flat, no-vectorize."""
-        codec = _FlatVSDocumentCodec(
-            content_field="content_x", ignore_invalid_documents=False
-        )
-        assert codec.encode_id(DOCUMENT_ID) == ID_FILTER
-
     def test_flat_novectorize_vectorsort_encoding(self) -> None:
         """Test vector-sort-encoding for flat, no-vectorize."""
         codec = _FlatVSDocumentCodec(
@@ -355,11 +417,6 @@ class TestVSDocCodecs:
         codec = _FlatVectorizeVSDocumentCodec(ignore_invalid_documents=False)
         assert codec.decode_vector(ASTRA_FLAT_DOCUMENT_VECTORIZE_READ) == VECTOR
         assert codec.decode_vector({}) is None
-
-    def test_flat_vectorize_id_encoding(self) -> None:
-        """Test id-encoding for flat, vectorize."""
-        codec = _FlatVectorizeVSDocumentCodec(ignore_invalid_documents=False)
-        assert codec.encode_id(DOCUMENT_ID) == ID_FILTER
 
     def test_flat_vectorize_vectorsort_encoding(self) -> None:
         """Test vector-sort-encoding for flat, vectorize."""

--- a/libs/astradb/tests/unit_tests/test_vs_doc_codecs.py
+++ b/libs/astradb/tests/unit_tests/test_vs_doc_codecs.py
@@ -365,3 +365,20 @@ class TestVSDocCodecs:
         """Test vector-sort-encoding for flat, vectorize."""
         codec = _FlatVectorizeVSDocumentCodec(ignore_invalid_documents=False)
         assert codec.encode_vector_sort(VECTOR) == VECTOR_SORT
+
+    def test_codec_default_collection_indexing_policy(self) -> None:
+        """Test all codecs give their expected default indexing settings back."""
+        codec_d_n = _DefaultVSDocumentCodec(
+            content_field="content_x",
+            ignore_invalid_documents=False,
+        )
+        assert codec_d_n.default_collection_indexing_policy == {"allow": ["metadata"]}
+        codec_d_v = _DefaultVectorizeVSDocumentCodec(ignore_invalid_documents=True)
+        assert codec_d_v.default_collection_indexing_policy == {"allow": ["metadata"]}
+        codec_f_n = _FlatVSDocumentCodec(
+            content_field="content_x",
+            ignore_invalid_documents=False,
+        )
+        assert codec_f_n.default_collection_indexing_policy == {"deny": ["content_x"]}
+        codec_f_v = _FlatVectorizeVSDocumentCodec(ignore_invalid_documents=True)
+        assert codec_f_v.default_collection_indexing_policy == {}


### PR DESCRIPTION
Clean separation of codecs/vectorstore layers

This PR introduces a better separation of knowledge on what pertains to codecs and what constitutes the underlying logic of the Vector Store. As such,

fixes #106 

Meanwhile, it provides a couple of useful querying tools which feel like they belong to the vstore+codec layer. (though another such tool, the "run_query" method, is postponed to a follow-up PR. That one is possibly the most important of these.)

Additionally, this restructuring of the code also makes a step toward a possible extension to cover API Tables without duplicating logic.

More in detail:

- creation of "id queries" in the codec consistently (away from vectorstore)
- moved id- and $vector-related parts of codec into the base class (not expected to vary under the data api)
- codecs expose their "default indexing policy", vectorstore uses that knowledge in and around its constructor ( --> for coll. creation in particular)
- codecs expose their "abstract metadata key to actual dot-notation field identifier" for building include/exclude policies specified by _metadata_ fields
- vectorstore does not say "_id" literally anymore (all is in codec; uses get_id)

A **note** on the name chosen for the `get_id` codec method. There is the unfortunate fact that LangChain calls "documents" its internal format, and Astra DB calls "document" what it stores. So ... codecs that lie between these two have sometimes a hard time with naming. Keeping it simple (`get_id`) should work in this case because only one of the two ends of the codec (the Astra side) can have a variable schema: then, only on that side should the need arise for a function abstracting the reading of an ID. (Which btw is more a formality as the `"_id"` field is one of those that will hardly ever change in Astra DB!)
