### PR TITLE
Vector store's run_query method

### DIFF
--- a/libs/astradb/langchain_astradb/utils/vector_store_codecs.py
+++ b/libs/astradb/langchain_astradb/utils/vector_store_codecs.py
@@ -218,12 +218,9 @@ class _AstraDBVectorStoreDocumentCodec(ABC):
         """Return the ID of an encoded document (= a raw JSON read from DB)."""
         return astra_document["_id"]
 
-    def get_similarity(self, astra_document: dict[str, Any]) -> float:
-        """Return the similarity of an encoded document (= a raw JSON read from DB).
-
-        This method assumes its argument comes from a suitable vector search.
-        """
-        return astra_document[SIMILARITY_FIELD_NAME]
+    def get_similarity(self, astra_document: dict[str, Any]) -> float | None:
+        """Return the similarity of an encoded document (= a raw JSON read from DB)."""
+        return astra_document.get(SIMILARITY_FIELD_NAME)
 
     def encode_query(
         self,

--- a/libs/astradb/langchain_astradb/vectorstores.py
+++ b/libs/astradb/langchain_astradb/vectorstores.py
@@ -19,6 +19,7 @@ from typing import (
     Sequence,
     TypeVar,
     cast,
+    overload,
 )
 
 import numpy as np
@@ -64,6 +65,7 @@ if TYPE_CHECKING:
 
 T = TypeVar("T")
 U = TypeVar("U")
+V = TypeVar("V")
 DocDict = Dict[str, Any]  # dicts expressing entries to insert
 
 # error code to check for during bulk insertions
@@ -1445,19 +1447,53 @@ class AstraDBVectorStore(VectorStore):
 
         return sum(u_res.update_info["n"] for u_res in update_results)
 
+    @overload
     def run_query(
         self,
         *,
         n: int,
+        raw_document_mapper: None = ...,
+        ids: list[str] | None = None,
+        filter: dict[str, Any] | None = None,
+        sort: dict[str, Any] | None = None,
+        include_similarity: bool | None = None,
+        include_sort_vector: bool | None = None,
+        include_embeddings: bool | None = None,
+    ) -> tuple[
+        list[float] | None,
+        Iterable[tuple[Document, str, list[float] | None, float | None]],
+    ]: ...
+
+    @overload
+    def run_query(
+        self,
+        *,
+        n: int,
+        raw_document_mapper: Callable[[DocDict], V | None],
+        ids: list[str] | None = None,
+        filter: dict[str, Any] | None = None,
+        sort: dict[str, Any] | None = None,
+        include_similarity: bool | None = None,
+        include_sort_vector: bool | None = None,
+        include_embeddings: bool | None = None,
+    ) -> tuple[
+        list[float] | None, Iterable[tuple[V, str, list[float] | None, float | None]]
+    ]: ...
+
+    def run_query(
+        self,
+        *,
+        n: int,
+        raw_document_mapper: Callable[[DocDict], V | None] | None = None,
         ids: list[str] | None = None,
         filter: dict[str, Any] | None = None,  # noqa: A002
         sort: dict[str, Any] | None = None,
         include_similarity: bool | None = None,
         include_sort_vector: bool | None = None,
         include_embeddings: bool | None = None,
-        raw_document_mapper: Callable[[DocDict], Any | None] | None = None,
     ) -> tuple[
-        list[float] | None, Iterable[tuple[Any, str, list[float] | None, float | None]]
+        list[float] | None,
+        Iterable[tuple[V | Document, str, list[float] | None, float | None]],
     ]:
         """Execute a generic query on stored documents.
 
@@ -1573,20 +1609,54 @@ class AstraDBVectorStore(VectorStore):
         )
         return sort_vector, final_doc_iterator
 
+    @overload
     async def arun_query(
         self,
         *,
         n: int,
+        raw_document_mapper: None = ...,
+        ids: list[str] | None = None,
+        filter: dict[str, Any] | None = None,
+        sort: dict[str, Any] | None = None,
+        include_similarity: bool | None = None,
+        include_sort_vector: bool | None = None,
+        include_embeddings: bool | None = None,
+    ) -> tuple[
+        list[float] | None,
+        AsyncIterable[tuple[Document, str, list[float] | None, float | None]],
+    ]: ...
+
+    @overload
+    async def arun_query(
+        self,
+        *,
+        n: int,
+        raw_document_mapper: Callable[[DocDict], V | None],
+        ids: list[str] | None = None,
+        filter: dict[str, Any] | None = None,
+        sort: dict[str, Any] | None = None,
+        include_similarity: bool | None = None,
+        include_sort_vector: bool | None = None,
+        include_embeddings: bool | None = None,
+    ) -> tuple[
+        list[float] | None,
+        AsyncIterable[tuple[V, str, list[float] | None, float | None]],
+    ]: ...
+
+    async def arun_query(
+        self,
+        *,
+        n: int,
+        raw_document_mapper: Callable[[DocDict], V | None] | None = None,
         ids: list[str] | None = None,
         filter: dict[str, Any] | None = None,  # noqa: A002
         sort: dict[str, Any] | None = None,
         include_similarity: bool | None = None,
         include_sort_vector: bool | None = None,
         include_embeddings: bool | None = None,
-        raw_document_mapper: Callable[[DocDict], Any | None] | None = None,
     ) -> tuple[
         list[float] | None,
-        AsyncIterable[tuple[Any, str, list[float] | None, float | None]],
+        AsyncIterable[tuple[V | Document, str, list[float] | None, float | None]],
     ]:
         """Execute a generic query on stored documents.
 

--- a/libs/astradb/langchain_astradb/vectorstores.py
+++ b/libs/astradb/langchain_astradb/vectorstores.py
@@ -1463,6 +1463,9 @@ class AstraDBVectorStore(VectorStore):
 
         projection is dictated by include_embeddings essentially
 
+        Note: If passing a mapping, you may want to take care of the invalid docs
+        (which the codec may be configured to do otherwise).
+
         Note: if codec skips invalid docs, you may get <k results even if
         there were more.
         """
@@ -1494,7 +1497,7 @@ class AstraDBVectorStore(VectorStore):
         sort_vector = find_raw_iterator.get_sort_vector()
         final_doc_iterator = (
             (
-                mapper(raw_doc),
+                mapped_doc,
                 self.document_codec.get_id(raw_doc),
                 raw_doc.get("$vector") if include_embeddings else None,
                 self.document_codec.get_similarity(raw_doc)
@@ -1502,6 +1505,7 @@ class AstraDBVectorStore(VectorStore):
                 else None,
             )
             for raw_doc in find_raw_iterator
+            if (mapped_doc := mapper(raw_doc)) is not None
         )
         return sort_vector, final_doc_iterator
 

--- a/libs/astradb/langchain_astradb/vectorstores.py
+++ b/libs/astradb/langchain_astradb/vectorstores.py
@@ -68,7 +68,7 @@ U = TypeVar("U")
 DocDict = Dict[str, Any]  # dicts expressing entries to insert
 
 
-class FullQueryResult(NamedTuple):
+class AstraDBQueryResult(NamedTuple):
     """The complete information contained in a vector store entry.
 
     This class represents all that can be returned from the collection when running
@@ -1463,7 +1463,7 @@ class AstraDBVectorStore(VectorStore):
     def full_decode_astra_db_document(
         self,
         astra_db_document: DocDict,
-    ) -> FullQueryResult | None:
+    ) -> AstraDBQueryResult | None:
         """Decode an Astra DB document in full, i.e. into Document+embedding/similarity.
 
         This operation returns a representation that is independent of the codec
@@ -1482,7 +1482,7 @@ class AstraDBVectorStore(VectorStore):
                 the collection.
 
         Returns:
-            a FullQueryResult named tuple with Document, id, embedding
+            a AstraDBQueryResult named tuple with Document, id, embedding
                 (where applicable) and similarity (where applicable),
                 or an overall None if the decoding is refused by the codec.
         """
@@ -1491,7 +1491,7 @@ class AstraDBVectorStore(VectorStore):
             doc_id = self.document_codec.get_id(astra_db_document)
             doc_embedding = self.document_codec.decode_vector(astra_db_document)
             doc_similarity = self.document_codec.get_similarity(astra_db_document)
-            return FullQueryResult(
+            return AstraDBQueryResult(
                 document=decoded,
                 id=doc_id,
                 embedding=doc_embedding,
@@ -1506,9 +1506,9 @@ class AstraDBVectorStore(VectorStore):
         ids: list[str] | None = None,
         filter: dict[str, Any] | None = None,  # noqa: A002
         sort: dict[str, Any] | None = None,
-        include_similarity: bool | None = None,
-        include_sort_vector: bool | None = None,
-        include_embeddings: bool | None = None,
+        include_similarity: bool = False,
+        include_sort_vector: bool = False,
+        include_embeddings: bool = False,
     ) -> tuple[list[float] | None, Iterable[DocDict]]:
         """Execute a generic query on stored documents, returning Astra DB documents.
 
@@ -1593,10 +1593,10 @@ class AstraDBVectorStore(VectorStore):
         ids: list[str] | None = None,
         filter: dict[str, Any] | None = None,  # noqa: A002
         sort: dict[str, Any] | None = None,
-        include_similarity: bool | None = None,
-        include_sort_vector: bool | None = None,
-        include_embeddings: bool | None = None,
-    ) -> tuple[list[float] | None, Iterable[FullQueryResult]]:
+        include_similarity: bool = False,
+        include_sort_vector: bool = False,
+        include_embeddings: bool = False,
+    ) -> tuple[list[float] | None, Iterable[AstraDBQueryResult]]:
         """Execute a generic query on stored documents, returning Documents+other info.
 
         The return value has a fixed format, which accommodates for possible quantities
@@ -1639,7 +1639,7 @@ class AstraDBVectorStore(VectorStore):
             A tuple `(query_vector, full_results_iterable)`, where:
             * `query_vector` is the vector used in the ANN search, if requested
                 and applicable;
-            * `full_results_iterable` is an iterable over the FullQueryResult items
+            * `full_results_iterable` is an iterable over the AstraDBQueryResult items
                 returned by the query. Entries that fail the decoding step, if any,
                 are discarded after the query, which may lead to fewer items being
                 returned than the required `n`.
@@ -1670,9 +1670,9 @@ class AstraDBVectorStore(VectorStore):
         ids: list[str] | None = None,
         filter: dict[str, Any] | None = None,  # noqa: A002
         sort: dict[str, Any] | None = None,
-        include_similarity: bool | None = None,
-        include_sort_vector: bool | None = None,
-        include_embeddings: bool | None = None,
+        include_similarity: bool = False,
+        include_sort_vector: bool = False,
+        include_embeddings: bool = False,
     ) -> tuple[list[float] | None, AsyncIterable[DocDict]]:
         """Execute a generic query on stored documents, returning Astra DB documents.
 
@@ -1758,10 +1758,10 @@ class AstraDBVectorStore(VectorStore):
         ids: list[str] | None = None,
         filter: dict[str, Any] | None = None,  # noqa: A002
         sort: dict[str, Any] | None = None,
-        include_similarity: bool | None = None,
-        include_sort_vector: bool | None = None,
-        include_embeddings: bool | None = None,
-    ) -> tuple[list[float] | None, AsyncIterable[FullQueryResult]]:
+        include_similarity: bool = False,
+        include_sort_vector: bool = False,
+        include_embeddings: bool = False,
+    ) -> tuple[list[float] | None, AsyncIterable[AstraDBQueryResult]]:
         """Execute a generic query on stored documents, returning Documents+other info.
 
         The return value has a fixed format, which accommodates for possible quantities
@@ -1803,7 +1803,7 @@ class AstraDBVectorStore(VectorStore):
             A tuple `(query_vector, full_results_iterable)`, where:
             * `query_vector` is the vector used in the ANN search, if requested
                 and applicable;
-            * `full_results_iterable` is an iterable over the FullQueryResult items
+            * `full_results_iterable` is an iterable over the AstraDBQueryResult items
                 returned by the query. Entries that fail the decoding step, if any,
                 are discarded after the query, which may lead to fewer items being
                 returned than the required `n`.

--- a/libs/astradb/langchain_astradb/vectorstores.py
+++ b/libs/astradb/langchain_astradb/vectorstores.py
@@ -2296,7 +2296,7 @@ class AstraDBVectorStore(VectorStore):
     ) -> list[Document]:
         sort_vec, hits_ite = self.run_query(
             n=fetch_k,
-            filter=filter,,
+            filter=filter,
             sort=sort,
             include_sort_vector=True,
             include_embeddings=True,

--- a/libs/astradb/langchain_astradb/vectorstores.py
+++ b/libs/astradb/langchain_astradb/vectorstores.py
@@ -1525,7 +1525,7 @@ class AstraDBVectorStore(VectorStore):
                 only document with an ID among the provided one will match. If further
                 query filters are provided (i.e. metadata), matches must satisfy both
                 requirements.
-            filter: a metadata filtering part. If provided, if must refer to
+            filter: a metadata filtering part. If provided, it must refer to
                 metadata keys by their bare name (such as `{"key": 123}`).
                 This filter can combine nested conditions with "$or"/"$and" connectors,
                 for example:
@@ -1688,7 +1688,7 @@ class AstraDBVectorStore(VectorStore):
                 only document with an ID among the provided one will match. If further
                 query filters are provided (i.e. metadata), matches must satisfy both
                 requirements.
-            filter: a metadata filtering part. If provided, if must refer to
+            filter: a metadata filtering part. If provided, it must refer to
                 metadata keys by their bare name (such as `{"key": 123}`).
                 This filter can combine nested conditions with "$or"/"$and" connectors,
                 for example:

--- a/libs/astradb/tests/integration_tests/test_vectorstore.py
+++ b/libs/astradb/tests/integration_tests/test_vectorstore.py
@@ -2008,28 +2008,6 @@ class TestAstraDBVectorStore:
         assert isinstance(hits7_l[0][2][0], (int, float))
         assert hits7_l[0][3] is None
 
-        # use a custom mapper
-        search_vector8, hits8 = vstore.run_query(
-            n=2,
-            ids=["1", "2", "6", "7", "9", "10"],
-            filter={"$or": [{"a": "a"}, {"b": "b"}]},
-            sort=sort_clause,
-            include_similarity=False,
-            include_sort_vector=False,
-            include_embeddings=False,
-            raw_document_mapper=lambda raw_doc: "/".join(sorted(raw_doc.keys())),
-        )
-        hits8_l = list(hits8)
-        assert search_vector8 is None
-        assert len(hits8_l) >= 2  # sometimes _id-based queries return more.
-        assert len(hits8_l) <= 4
-        assert hits8_l[0][0] == (
-            "$vectorize/_id/metadata" if is_vectorize else "_id/content/metadata"
-        )
-        assert hits8_l[0][1] in {"1", "2", "6", "7"}
-        assert hits8_l[0][2] is None
-        assert hits8_l[0][3] is None
-
         # nonvector sort
         _, hits9a = vstore.run_query(
             n=3,
@@ -2223,28 +2201,6 @@ class TestAstraDBVectorStore:
         assert isinstance(hits7_l[0][2], list)
         assert isinstance(hits7_l[0][2][0], (int, float))
         assert hits7_l[0][3] is None
-
-        # use a custom mapper
-        search_vector8, hits8 = await vstore.arun_query(
-            n=2,
-            ids=["1", "2", "6", "7", "9", "10"],
-            filter={"$or": [{"a": "a"}, {"b": "b"}]},
-            sort=sort_clause,
-            include_similarity=False,
-            include_sort_vector=False,
-            include_embeddings=False,
-            raw_document_mapper=lambda raw_doc: "/".join(sorted(raw_doc.keys())),
-        )
-        hits8_l = [tpl async for tpl in hits8]
-        assert search_vector8 is None
-        assert len(hits8_l) >= 2  # sometimes _id-based queries return more.
-        assert len(hits8_l) <= 4
-        assert hits8_l[0][0] == (
-            "$vectorize/_id/metadata" if is_vectorize else "_id/content/metadata"
-        )
-        assert hits8_l[0][1] in {"1", "2", "6", "7"}
-        assert hits8_l[0][2] is None
-        assert hits8_l[0][3] is None
 
         # nonvector sort
         _, hits9a = await vstore.arun_query(

--- a/libs/astradb/tests/integration_tests/test_vectorstore.py
+++ b/libs/astradb/tests/integration_tests/test_vectorstore.py
@@ -1883,9 +1883,8 @@ class TestAstraDBVectorStore:
         )
 
         # baseline
-        search_vector0, hits0 = vstore.run_query(n=5)
+        hits0 = vstore.run_query(n=5)
         hits0_l = list(hits0)
-        assert search_vector0 is None
         assert len(hits0_l) == 5
         assert isinstance(hits0_l[0][0], Document)
         assert isinstance(hits0_l[0][1], str)
@@ -1893,12 +1892,11 @@ class TestAstraDBVectorStore:
         assert hits0_l[0][3] is None
 
         # just id
-        search_vector1, hits1 = vstore.run_query(
+        hits1 = vstore.run_query(
             n=2,
             ids=["5", "6", "7", "8"],
         )
         hits1_l = list(hits1)
-        assert search_vector1 is None
         assert len(hits1_l) >= 2  # sometimes _id-based queries return more.
         assert len(hits1_l) <= 4
         assert isinstance(hits1_l[0][0], Document)
@@ -1907,12 +1905,11 @@ class TestAstraDBVectorStore:
         assert hits1_l[0][3] is None
 
         # just simple filters
-        search_vector2, hits2 = vstore.run_query(
+        hits2 = vstore.run_query(
             n=20,
             filter={"a": "a"},
         )
         hits2_l = list(hits2)
-        assert search_vector2 is None
         assert len(hits2_l) == 5
         assert isinstance(hits2_l[0][0], Document)
         assert hits2_l[0][1] in {"1", "2", "3", "4", "5"}
@@ -1920,12 +1917,11 @@ class TestAstraDBVectorStore:
         assert hits2_l[0][3] is None
 
         # just elaborate filters
-        search_vector3, hits3 = vstore.run_query(
+        hits3 = vstore.run_query(
             n=30,
             filter={"$or": [{"a": "a"}, {"b": "b"}]},
         )
         hits3_l = list(hits3)
-        assert search_vector3 is None
         assert len(hits3_l) == 7
         assert isinstance(hits3_l[0][0], Document)
         assert hits3_l[0][1] in {"1", "2", "3", "4", "5", "6", "7"}
@@ -1934,13 +1930,12 @@ class TestAstraDBVectorStore:
         assert hits3_l[0][3] is None
 
         # id + filters
-        search_vector4, hits4 = vstore.run_query(
+        hits4 = vstore.run_query(
             n=2,
             ids=["1", "2", "6", "7", "9", "10"],
             filter={"$or": [{"a": "a"}, {"b": "b"}]},
         )
         hits4_l = list(hits4)
-        assert search_vector4 is None
         assert len(hits4_l) >= 2  # sometimes _id-based queries return more.
         assert len(hits4_l) <= 4
         assert isinstance(hits4_l[0][0], Document)
@@ -1950,7 +1945,7 @@ class TestAstraDBVectorStore:
         assert hits4_l[0][3] is None
 
         # get similarity
-        search_vector5, hits5 = vstore.run_query(
+        hits5 = vstore.run_query(
             n=2,
             ids=["1", "2", "6", "7", "9", "10"],
             filter={"$or": [{"a": "a"}, {"b": "b"}]},
@@ -1960,7 +1955,6 @@ class TestAstraDBVectorStore:
             include_embeddings=False,
         )
         hits5_l = list(hits5)
-        assert search_vector5 is None
         assert len(hits5_l) >= 2  # sometimes _id-based queries return more.
         assert len(hits5_l) <= 4
         assert isinstance(hits5_l[0][0], Document)
@@ -1989,7 +1983,7 @@ class TestAstraDBVectorStore:
         assert hits6_l[0][3] is None
 
         # get embeddings
-        search_vector7, hits7 = vstore.run_query(
+        hits7 = vstore.run_query(
             n=2,
             ids=["1", "2", "6", "7", "9", "10"],
             filter={"$or": [{"a": "a"}, {"b": "b"}]},
@@ -1999,7 +1993,6 @@ class TestAstraDBVectorStore:
             include_embeddings=True,
         )
         hits7_l = list(hits7)
-        assert search_vector7 is None
         assert len(hits7_l) >= 2  # sometimes _id-based queries return more.
         assert len(hits7_l) <= 4
         assert isinstance(hits7_l[0][0], Document)
@@ -2009,13 +2002,13 @@ class TestAstraDBVectorStore:
         assert hits7_l[0][3] is None
 
         # nonvector sort
-        _, hits9a = vstore.run_query(
+        hits9a = vstore.run_query(
             n=3,
             sort={"int_index": SortDocuments.ASCENDING},
         )
         hits9a_l = list(hits9a)
         assert [doc_id for _, doc_id, _, _ in hits9a_l] == ["1", "2", "3"]
-        _, hits9d = vstore.run_query(
+        hits9d = vstore.run_query(
             n=3,
             sort={"int_index": SortDocuments.DESCENDING},
         )
@@ -2077,9 +2070,8 @@ class TestAstraDBVectorStore:
         )
 
         # baseline
-        search_vector0, hits0 = await vstore.arun_query(n=5)
+        hits0 = await vstore.arun_query(n=5)
         hits0_l = [tpl async for tpl in hits0]
-        assert search_vector0 is None
         assert len(hits0_l) == 5
         assert isinstance(hits0_l[0][0], Document)
         assert isinstance(hits0_l[0][1], str)
@@ -2087,12 +2079,11 @@ class TestAstraDBVectorStore:
         assert hits0_l[0][3] is None
 
         # just id
-        search_vector1, hits1 = await vstore.arun_query(
+        hits1 = await vstore.arun_query(
             n=2,
             ids=["5", "6", "7", "8"],
         )
         hits1_l = [tpl async for tpl in hits1]
-        assert search_vector1 is None
         assert len(hits1_l) >= 2  # sometimes _id-based queries return more.
         assert len(hits1_l) <= 4
         assert isinstance(hits1_l[0][0], Document)
@@ -2101,12 +2092,11 @@ class TestAstraDBVectorStore:
         assert hits1_l[0][3] is None
 
         # just simple filters
-        search_vector2, hits2 = await vstore.arun_query(
+        hits2 = await vstore.arun_query(
             n=20,
             filter={"a": "a"},
         )
         hits2_l = [tpl async for tpl in hits2]
-        assert search_vector2 is None
         assert len(hits2_l) == 5
         assert isinstance(hits2_l[0][0], Document)
         assert hits2_l[0][1] in {"1", "2", "3", "4", "5"}
@@ -2114,12 +2104,11 @@ class TestAstraDBVectorStore:
         assert hits2_l[0][3] is None
 
         # just elaborate filters
-        search_vector3, hits3 = await vstore.arun_query(
+        hits3 = await vstore.arun_query(
             n=30,
             filter={"$or": [{"a": "a"}, {"b": "b"}]},
         )
         hits3_l = [tpl async for tpl in hits3]
-        assert search_vector3 is None
         assert len(hits3_l) == 7
         assert isinstance(hits3_l[0][0], Document)
         assert hits3_l[0][1] in {"1", "2", "3", "4", "5", "6", "7"}
@@ -2128,13 +2117,12 @@ class TestAstraDBVectorStore:
         assert hits3_l[0][3] is None
 
         # id + filters
-        search_vector4, hits4 = await vstore.arun_query(
+        hits4 = await vstore.arun_query(
             n=2,
             ids=["1", "2", "6", "7", "9", "10"],
             filter={"$or": [{"a": "a"}, {"b": "b"}]},
         )
         hits4_l = [tpl async for tpl in hits4]
-        assert search_vector4 is None
         assert len(hits4_l) >= 2  # sometimes _id-based queries return more.
         assert len(hits4_l) <= 4
         assert isinstance(hits4_l[0][0], Document)
@@ -2144,7 +2132,7 @@ class TestAstraDBVectorStore:
         assert hits4_l[0][3] is None
 
         # get similarity
-        search_vector5, hits5 = await vstore.arun_query(
+        hits5 = await vstore.arun_query(
             n=2,
             ids=["1", "2", "6", "7", "9", "10"],
             filter={"$or": [{"a": "a"}, {"b": "b"}]},
@@ -2154,7 +2142,6 @@ class TestAstraDBVectorStore:
             include_embeddings=False,
         )
         hits5_l = [tpl async for tpl in hits5]
-        assert search_vector5 is None
         assert len(hits5_l) >= 2  # sometimes _id-based queries return more.
         assert len(hits5_l) <= 4
         assert isinstance(hits5_l[0][0], Document)
@@ -2183,7 +2170,7 @@ class TestAstraDBVectorStore:
         assert hits6_l[0][3] is None
 
         # get embeddings
-        search_vector7, hits7 = await vstore.arun_query(
+        hits7 = await vstore.arun_query(
             n=2,
             ids=["1", "2", "6", "7", "9", "10"],
             filter={"$or": [{"a": "a"}, {"b": "b"}]},
@@ -2193,7 +2180,6 @@ class TestAstraDBVectorStore:
             include_embeddings=True,
         )
         hits7_l = [tpl async for tpl in hits7]
-        assert search_vector7 is None
         assert len(hits7_l) >= 2  # sometimes _id-based queries return more.
         assert len(hits7_l) <= 4
         assert isinstance(hits7_l[0][0], Document)
@@ -2203,13 +2189,13 @@ class TestAstraDBVectorStore:
         assert hits7_l[0][3] is None
 
         # nonvector sort
-        _, hits9a = await vstore.arun_query(
+        hits9a = await vstore.arun_query(
             n=3,
             sort={"int_index": SortDocuments.ASCENDING},
         )
         hits9a_l = [tpl async for tpl in hits9a]
         assert [doc_id for _, doc_id, _, _ in hits9a_l] == ["1", "2", "3"]
-        _, hits9d = await vstore.arun_query(
+        hits9d = await vstore.arun_query(
             n=3,
             sort={"int_index": SortDocuments.DESCENDING},
         )

--- a/libs/astradb/tests/integration_tests/test_vectorstore.py
+++ b/libs/astradb/tests/integration_tests/test_vectorstore.py
@@ -1878,6 +1878,9 @@ class TestAstraDBVectorStore:
             for i in range(10)
         ]
         vstore.add_documents(documents_to_insert)
+        sort_clause: dict[str, list[float] | str] = (
+            {"$vectorize": "This is number 6"} if is_vectorize else {"$vector": [1, 6]}
+        )
 
         # baseline
         search_vector0, hits0 = vstore.run_query(n=5)
@@ -1951,11 +1954,7 @@ class TestAstraDBVectorStore:
             n=2,
             ids=["1", "2", "6", "7", "9", "10"],
             filter={"$or": [{"a": "a"}, {"b": "b"}]},
-            sort=(
-                {"$vectorize": "This is number 6"}
-                if is_vectorize
-                else {"$vector": [1, 6]}
-            ),
+            sort=sort_clause,
             include_similarity=True,
             include_sort_vector=False,
             include_embeddings=False,
@@ -1974,11 +1973,7 @@ class TestAstraDBVectorStore:
             n=2,
             ids=["1", "2", "6", "7", "9", "10"],
             filter={"$or": [{"a": "a"}, {"b": "b"}]},
-            sort=(
-                {"$vectorize": "This is number 6"}
-                if is_vectorize
-                else {"$vector": [1, 6]}
-            ),
+            sort=sort_clause,
             include_similarity=False,
             include_sort_vector=True,
             include_embeddings=False,
@@ -1998,11 +1993,7 @@ class TestAstraDBVectorStore:
             n=2,
             ids=["1", "2", "6", "7", "9", "10"],
             filter={"$or": [{"a": "a"}, {"b": "b"}]},
-            sort=(
-                {"$vectorize": "This is number 6"}
-                if is_vectorize
-                else {"$vector": [1, 6]}
-            ),
+            sort=sort_clause,
             include_similarity=False,
             include_sort_vector=False,
             include_embeddings=True,
@@ -2022,11 +2013,7 @@ class TestAstraDBVectorStore:
             n=2,
             ids=["1", "2", "6", "7", "9", "10"],
             filter={"$or": [{"a": "a"}, {"b": "b"}]},
-            sort=(
-                {"$vectorize": "This is number 6"}
-                if is_vectorize
-                else {"$vector": [1, 6]}
-            ),
+            sort=sort_clause,
             include_similarity=False,
             include_sort_vector=False,
             include_embeddings=False,
@@ -2107,6 +2094,9 @@ class TestAstraDBVectorStore:
             for i in range(10)
         ]
         await vstore.aadd_documents(documents_to_insert)
+        sort_clause: dict[str, list[float] | str] = (
+            {"$vectorize": "This is number 6"} if is_vectorize else {"$vector": [1, 6]}
+        )
 
         # baseline
         search_vector0, hits0 = await vstore.arun_query(n=5)
@@ -2180,11 +2170,7 @@ class TestAstraDBVectorStore:
             n=2,
             ids=["1", "2", "6", "7", "9", "10"],
             filter={"$or": [{"a": "a"}, {"b": "b"}]},
-            sort=(
-                {"$vectorize": "This is number 6"}
-                if is_vectorize
-                else {"$vector": [1, 6]}
-            ),
+            sort=sort_clause,
             include_similarity=True,
             include_sort_vector=False,
             include_embeddings=False,
@@ -2203,11 +2189,7 @@ class TestAstraDBVectorStore:
             n=2,
             ids=["1", "2", "6", "7", "9", "10"],
             filter={"$or": [{"a": "a"}, {"b": "b"}]},
-            sort=(
-                {"$vectorize": "This is number 6"}
-                if is_vectorize
-                else {"$vector": [1, 6]}
-            ),
+            sort=sort_clause,
             include_similarity=False,
             include_sort_vector=True,
             include_embeddings=False,
@@ -2227,11 +2209,7 @@ class TestAstraDBVectorStore:
             n=2,
             ids=["1", "2", "6", "7", "9", "10"],
             filter={"$or": [{"a": "a"}, {"b": "b"}]},
-            sort=(
-                {"$vectorize": "This is number 6"}
-                if is_vectorize
-                else {"$vector": [1, 6]}
-            ),
+            sort=sort_clause,
             include_similarity=False,
             include_sort_vector=False,
             include_embeddings=True,
@@ -2251,11 +2229,7 @@ class TestAstraDBVectorStore:
             n=2,
             ids=["1", "2", "6", "7", "9", "10"],
             filter={"$or": [{"a": "a"}, {"b": "b"}]},
-            sort=(
-                {"$vectorize": "This is number 6"}
-                if is_vectorize
-                else {"$vector": [1, 6]}
-            ),
+            sort=sort_clause,
             include_similarity=False,
             include_sort_vector=False,
             include_embeddings=False,

--- a/libs/astradb/tests/integration_tests/test_vectorstore.py
+++ b/libs/astradb/tests/integration_tests/test_vectorstore.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING, Any
 
 import pytest
 from astrapy.authentication import EmbeddingAPIKeyHeaderProvider, StaticTokenProvider
+from astrapy.constants import SortDocuments
 from langchain_core.documents import Document
 
 from langchain_astradb.utils.astradb import COMPONENT_NAME_VECTORSTORE, SetupMode
@@ -1870,6 +1871,7 @@ class TestAstraDBVectorStore:
                     **({"a": "a"} if i < 5 else {}),
                     **({"b": "b"} if i < 7 and i >= 3 else {}),
                     **({"c": "c"} if i >= 5 else {}),
+                    "int_index": i + 1,
                 },
                 id=f"{i+1}",
             )
@@ -1949,7 +1951,7 @@ class TestAstraDBVectorStore:
             n=2,
             ids=["1", "2", "6", "7", "9", "10"],
             filter={"$or": [{"a": "a"}, {"b": "b"}]},
-            ann_sort=(
+            sort=(
                 {"$vectorize": "This is number 6"}
                 if is_vectorize
                 else {"$vector": [1, 6]}
@@ -1972,7 +1974,7 @@ class TestAstraDBVectorStore:
             n=2,
             ids=["1", "2", "6", "7", "9", "10"],
             filter={"$or": [{"a": "a"}, {"b": "b"}]},
-            ann_sort=(
+            sort=(
                 {"$vectorize": "This is number 6"}
                 if is_vectorize
                 else {"$vector": [1, 6]}
@@ -1996,7 +1998,7 @@ class TestAstraDBVectorStore:
             n=2,
             ids=["1", "2", "6", "7", "9", "10"],
             filter={"$or": [{"a": "a"}, {"b": "b"}]},
-            ann_sort=(
+            sort=(
                 {"$vectorize": "This is number 6"}
                 if is_vectorize
                 else {"$vector": [1, 6]}
@@ -2020,7 +2022,7 @@ class TestAstraDBVectorStore:
             n=2,
             ids=["1", "2", "6", "7", "9", "10"],
             filter={"$or": [{"a": "a"}, {"b": "b"}]},
-            ann_sort=(
+            sort=(
                 {"$vectorize": "This is number 6"}
                 if is_vectorize
                 else {"$vector": [1, 6]}
@@ -2040,6 +2042,20 @@ class TestAstraDBVectorStore:
         assert hits8_l[0][1] in {"1", "2", "6", "7"}
         assert hits8_l[0][2] is None
         assert hits8_l[0][3] is None
+
+        # nonvector sort
+        _, hits9a = vstore.run_query(
+            n=3,
+            sort={"int_index": SortDocuments.ASCENDING},
+        )
+        hits9a_l = list(hits9a)
+        assert [doc_id for _, doc_id, _, _ in hits9a_l] == ["1", "2", "3"]
+        _, hits9d = vstore.run_query(
+            n=3,
+            sort={"int_index": SortDocuments.DESCENDING},
+        )
+        hits9d_l = list(hits9d)
+        assert [doc_id for _, doc_id, _, _ in hits9d_l] == ["10", "9", "8"]
 
     @pytest.mark.parametrize(
         ("vector_store", "is_vectorize"),
@@ -2084,6 +2100,7 @@ class TestAstraDBVectorStore:
                     **({"a": "a"} if i < 5 else {}),
                     **({"b": "b"} if i < 7 and i >= 3 else {}),
                     **({"c": "c"} if i >= 5 else {}),
+                    "int_index": i + 1,
                 },
                 id=f"{i+1}",
             )
@@ -2163,7 +2180,7 @@ class TestAstraDBVectorStore:
             n=2,
             ids=["1", "2", "6", "7", "9", "10"],
             filter={"$or": [{"a": "a"}, {"b": "b"}]},
-            ann_sort=(
+            sort=(
                 {"$vectorize": "This is number 6"}
                 if is_vectorize
                 else {"$vector": [1, 6]}
@@ -2186,7 +2203,7 @@ class TestAstraDBVectorStore:
             n=2,
             ids=["1", "2", "6", "7", "9", "10"],
             filter={"$or": [{"a": "a"}, {"b": "b"}]},
-            ann_sort=(
+            sort=(
                 {"$vectorize": "This is number 6"}
                 if is_vectorize
                 else {"$vector": [1, 6]}
@@ -2210,7 +2227,7 @@ class TestAstraDBVectorStore:
             n=2,
             ids=["1", "2", "6", "7", "9", "10"],
             filter={"$or": [{"a": "a"}, {"b": "b"}]},
-            ann_sort=(
+            sort=(
                 {"$vectorize": "This is number 6"}
                 if is_vectorize
                 else {"$vector": [1, 6]}
@@ -2234,7 +2251,7 @@ class TestAstraDBVectorStore:
             n=2,
             ids=["1", "2", "6", "7", "9", "10"],
             filter={"$or": [{"a": "a"}, {"b": "b"}]},
-            ann_sort=(
+            sort=(
                 {"$vectorize": "This is number 6"}
                 if is_vectorize
                 else {"$vector": [1, 6]}
@@ -2254,3 +2271,17 @@ class TestAstraDBVectorStore:
         assert hits8_l[0][1] in {"1", "2", "6", "7"}
         assert hits8_l[0][2] is None
         assert hits8_l[0][3] is None
+
+        # nonvector sort
+        _, hits9a = await vstore.arun_query(
+            n=3,
+            sort={"int_index": SortDocuments.ASCENDING},
+        )
+        hits9a_l = [tpl async for tpl in hits9a]
+        assert [doc_id for _, doc_id, _, _ in hits9a_l] == ["1", "2", "3"]
+        _, hits9d = await vstore.arun_query(
+            n=3,
+            sort={"int_index": SortDocuments.DESCENDING},
+        )
+        hits9d_l = [tpl async for tpl in hits9d]
+        assert [doc_id for _, doc_id, _, _ in hits9d_l] == ["10", "9", "8"]

--- a/libs/astradb/tests/integration_tests/test_vectorstore.py
+++ b/libs/astradb/tests/integration_tests/test_vectorstore.py
@@ -1828,3 +1828,215 @@ class TestAstraDBVectorStore:
         assert vstore2.astra_env.ext_callers == [("cnx", "cvx")]
         assert vstore2.astra_env.component_name == "component_name2"
         assert vstore2.astra_env.collection_embedding_api_key == apikey2
+
+    @pytest.mark.parametrize(
+        ("vector_store", "is_vectorize"),
+        [
+            ("vector_store_d2", False),
+            ("vector_store_vz", True),
+        ],
+        ids=[
+            "nonvectorize_store",
+            "vectorize_store",
+        ],
+    )
+    def test_astradb_vectorstore_run_query(
+        self,
+        *,
+        vector_store: str,
+        is_vectorize: bool,
+        request: pytest.FixtureRequest,
+    ) -> None:
+        """Structure of the metadata/vector for the 'run_query' test:
+        ID      a       b       c       vec(when 2d)
+        --------------------------------------------
+         '1'    'a'                     [1,1]
+         '2'    'a'                     [1,2]
+         '3'    'a'                     ...
+         '4'    'a'     'b'             ...
+         '5'    'a'     'b'
+         '6'            'b'     'c'
+         '7'            'b'     'c'
+         '8'                    'c'
+         '9'                    'c'
+        '10'                    'c'     [1,10]
+        """
+        vstore: AstraDBVectorStore = request.getfixturevalue(vector_store)
+
+        documents_to_insert = [
+            Document(
+                page_content=f"This is number {i+1}" if is_vectorize else f"[1,{i+1}]",
+                metadata={
+                    **({"a": "a"} if i < 5 else {}),
+                    **({"b": "b"} if i < 7 and i >= 3 else {}),
+                    **({"c": "c"} if i >= 5 else {}),
+                },
+                id=f"{i+1}",
+            )
+            for i in range(10)
+        ]
+        vstore.add_documents(documents_to_insert)
+
+        # baseline
+        search_vector0, hits0 = vstore.run_query(n=5)
+        hits0_l = list(hits0)
+        assert search_vector0 is None
+        assert len(hits0_l) == 5
+        assert isinstance(hits0_l[0][0], Document)
+        assert isinstance(hits0_l[0][1], str)
+        assert hits0_l[0][2] is None
+        assert hits0_l[0][3] is None
+
+        # just id
+        search_vector1, hits1 = vstore.run_query(
+            n=2,
+            ids=["5", "6", "7", "8"],
+        )
+        hits1_l = list(hits1)
+        assert search_vector1 is None
+        assert len(hits1_l) >= 2  # sometimes _id-based queries return more.
+        assert len(hits1_l) <= 4
+        assert isinstance(hits1_l[0][0], Document)
+        assert hits1_l[0][1] in {"5", "6", "7", "8"}
+        assert hits1_l[0][2] is None
+        assert hits1_l[0][3] is None
+
+        # just simple filters
+        search_vector2, hits2 = vstore.run_query(
+            n=20,
+            filter={"a": "a"},
+        )
+        hits2_l = list(hits2)
+        assert search_vector2 is None
+        assert len(hits2_l) == 5
+        assert isinstance(hits2_l[0][0], Document)
+        assert hits2_l[0][1] in {"1", "2", "3", "4", "5"}
+        assert hits2_l[0][2] is None
+        assert hits2_l[0][3] is None
+
+        # just elaborate filters
+        search_vector3, hits3 = vstore.run_query(
+            n=30,
+            filter={"$or": [{"a": "a"}, {"b": "b"}]},
+        )
+        hits3_l = list(hits3)
+        assert search_vector3 is None
+        assert len(hits3_l) == 7
+        assert isinstance(hits3_l[0][0], Document)
+        assert hits3_l[0][1] in {"1", "2", "3", "4", "5", "6", "7"}
+        assert all(hit[1] in {"1", "2", "3", "4", "5", "6", "7"} for hit in hits3_l)
+        assert hits3_l[0][2] is None
+        assert hits3_l[0][3] is None
+
+        # id + filters
+        search_vector4, hits4 = vstore.run_query(
+            n=2,
+            ids=["1", "2", "6", "7", "9", "10"],
+            filter={"$or": [{"a": "a"}, {"b": "b"}]},
+        )
+        hits4_l = list(hits4)
+        assert search_vector4 is None
+        assert len(hits4_l) >= 2  # sometimes _id-based queries return more.
+        assert len(hits4_l) <= 4
+        assert isinstance(hits4_l[0][0], Document)
+        assert hits4_l[0][1] in {"1", "2", "6", "7"}
+        assert all(hit[1] in {"1", "2", "6", "7"} for hit in hits4_l)
+        assert hits4_l[0][2] is None
+        assert hits4_l[0][3] is None
+
+        # get similarity
+        search_vector5, hits5 = vstore.run_query(
+            n=2,
+            ids=["1", "2", "6", "7", "9", "10"],
+            filter={"$or": [{"a": "a"}, {"b": "b"}]},
+            ann_sort=(
+                {"$vectorize": "This is number 6"}
+                if is_vectorize
+                else {"$vector": [1, 6]}
+            ),
+            include_similarity=True,
+            include_sort_vector=False,
+            include_embeddings=False,
+        )
+        hits5_l = list(hits5)
+        assert search_vector5 is None
+        assert len(hits5_l) >= 2  # sometimes _id-based queries return more.
+        assert len(hits5_l) <= 4
+        assert isinstance(hits5_l[0][0], Document)
+        assert hits5_l[0][1] in {"1", "2", "6", "7"}
+        assert hits5_l[0][2] is None
+        assert isinstance(hits5_l[0][3], float)
+
+        # get sortvector
+        search_vector6, hits6 = vstore.run_query(
+            n=2,
+            ids=["1", "2", "6", "7", "9", "10"],
+            filter={"$or": [{"a": "a"}, {"b": "b"}]},
+            ann_sort=(
+                {"$vectorize": "This is number 6"}
+                if is_vectorize
+                else {"$vector": [1, 6]}
+            ),
+            include_similarity=False,
+            include_sort_vector=True,
+            include_embeddings=False,
+        )
+        hits6_l = list(hits6)
+        assert isinstance(search_vector6, list)
+        assert isinstance(search_vector6[0], (int, float))
+        assert len(hits6_l) >= 2  # sometimes _id-based queries return more.
+        assert len(hits6_l) <= 4
+        assert isinstance(hits6_l[0][0], Document)
+        assert hits6_l[0][1] in {"1", "2", "6", "7"}
+        assert hits6_l[0][2] is None
+        assert hits6_l[0][3] is None
+
+        # get embeddings
+        search_vector7, hits7 = vstore.run_query(
+            n=2,
+            ids=["1", "2", "6", "7", "9", "10"],
+            filter={"$or": [{"a": "a"}, {"b": "b"}]},
+            ann_sort=(
+                {"$vectorize": "This is number 6"}
+                if is_vectorize
+                else {"$vector": [1, 6]}
+            ),
+            include_similarity=False,
+            include_sort_vector=False,
+            include_embeddings=True,
+        )
+        hits7_l = list(hits7)
+        assert search_vector7 is None
+        assert len(hits7_l) >= 2  # sometimes _id-based queries return more.
+        assert len(hits7_l) <= 4
+        assert isinstance(hits7_l[0][0], Document)
+        assert hits7_l[0][1] in {"1", "2", "6", "7"}
+        assert isinstance(hits7_l[0][2], list)
+        assert isinstance(hits7_l[0][2][0], (int, float))
+        assert hits7_l[0][3] is None
+
+        # use a custom mapper
+        search_vector8, hits8 = vstore.run_query(
+            n=2,
+            ids=["1", "2", "6", "7", "9", "10"],
+            filter={"$or": [{"a": "a"}, {"b": "b"}]},
+            ann_sort=(
+                {"$vectorize": "This is number 6"}
+                if is_vectorize
+                else {"$vector": [1, 6]}
+            ),
+            include_similarity=False,
+            include_sort_vector=False,
+            include_embeddings=False,
+            raw_document_mapper=lambda raw_doc: "/".join(sorted(raw_doc.keys())),
+        )
+        hits8_l = list(hits8)
+        assert search_vector8 is None
+        assert len(hits8_l) >= 2  # sometimes _id-based queries return more.
+        assert len(hits8_l) <= 4
+        assert hits8_l[0][0] == (
+            "$vectorize/_id/metadata" if is_vectorize else "_id/content/metadata"
+        )
+        assert hits8_l[0][1] in {"1", "2", "6", "7"}
+        assert hits8_l[0][2] is None
+        assert hits8_l[0][3] is None


### PR DESCRIPTION
This PR introduces a method `run_query` (+async equivalent) for the AstraDBVectorStore.

The method supports a variety of call patterns (ANN/non-ANN sorting, filters on ID and metadata; boolean flags to return embeddings, query vector, similarities; including a mapper function to transform the returned items).

The return value of `run_query` follows a fixed tuple-based schema, meant to be unpacked by the caller to pick what is needed: when some of the results are not requested (e.g. no embeddings), None values are found in the result (this saves some latency as it actually avoids their server-side computation and on-wire transfer).

This method aims at exposing an all-purpose method for running queries on a vector store that has three important properties:
1. clean separation of codec concerns and query logic. Callers of `run_query` are not supposed to know anythign about the actual structure of the documents on DB (unless they want to pass a custom mapping from raw returned documents, that is). The translation passes through the codec consistently in a manner managed by `run_query`
2. allows for enough flexibility in the query pattern to be reasonably seen as the one centralized piece of logic driving all interrogations of the collection;
3. ... and as such, in this PR, it is indeed used by all other read-path methods of the vector store, which defer to it (and its usage of the codecs).

Furthermore, this PR completes the few remaining pieces of the work initiated in #113 by moving a few raw-document interactions to the codec layer (for example, reading the `["$vector"]` of a document). Even though those do no harm if hardcoded in the vector store, (e.g. the location of the vector will hardly change in Data API), clean code organization required this separation to be formally complete.

A remaining concern is whether the (async) `arun_query` should optionally accept an **awaitable** mapper function. This is relevant only if said function performs blocking side-effects in its body. For the moment I assumed this not to be the case.