### PR TITLE
Expose (astrapy) APIOptions in all components

### DIFF
--- a/libs/astradb/langchain_astradb/cache.py
+++ b/libs/astradb/langchain_astradb/cache.py
@@ -23,6 +23,7 @@ from langchain_astradb.utils.astradb import (
 )
 
 if TYPE_CHECKING:
+    from astrapy.api_options import APIOptions
     from astrapy.authentication import TokenProvider
     from langchain_core.embeddings import Embeddings
     from langchain_core.language_models import LLM
@@ -117,6 +118,7 @@ class AstraDBCache(BaseCache):
         pre_delete_collection: bool = False,
         setup_mode: SetupMode = SetupMode.SYNC,
         ext_callers: list[tuple[str | None, str | None] | str | None] | None = None,
+        api_options: APIOptions | None = None,
     ):
         """Cache that uses Astra DB as a backend.
 
@@ -151,6 +153,13 @@ class AstraDBCache(BaseCache):
                 or just strings if no version info is provided, which, if supplied,
                 becomes the leading part of the User-Agent string in all API requests
                 related to this component.
+            api_options: an instance of ``astrapy.utils.api_options.APIOptions`` that
+                can be supplied to customize the interaction with the Data API
+                regarding serialization/deserialization, timeouts, custom headers
+                and so on. The provided options are applied on top of settings already
+                tailored to this library, and if specified will take precedence.
+                Passing None (default) means no customization is requested.
+                Refer to the astrapy documentation for details.
         """
         self.astra_env = _AstraDBCollectionEnvironment(
             collection_name=collection_name,
@@ -162,6 +171,7 @@ class AstraDBCache(BaseCache):
             pre_delete_collection=pre_delete_collection,
             ext_callers=ext_callers,
             component_name=COMPONENT_NAME_CACHE,
+            api_options=api_options,
         )
         self.collection = self.astra_env.collection
         self.async_collection = self.astra_env.async_collection
@@ -328,6 +338,7 @@ class AstraDBSemanticCache(BaseCache):
         metric: str | None = None,
         similarity_threshold: float = ASTRA_DB_SEMANTIC_CACHE_DEFAULT_THRESHOLD,
         ext_callers: list[tuple[str | None, str | None] | str | None] | None = None,
+        api_options: APIOptions | None = None,
     ):
         """Astra DB semantic cache.
 
@@ -372,6 +383,13 @@ class AstraDBSemanticCache(BaseCache):
                 or just strings if no version info is provided, which, if supplied,
                 becomes the leading part of the User-Agent string in all API requests
                 related to this component.
+            api_options: an instance of ``astrapy.utils.api_options.APIOptions`` that
+                can be supplied to customize the interaction with the Data API
+                regarding serialization/deserialization, timeouts, custom headers
+                and so on. The provided options are applied on top of settings already
+                tailored to this library, and if specified will take precedence.
+                Passing None (default) means no customization is requested.
+                Refer to the astrapy documentation for details.
         """
         self.embedding = embedding
         self.metric = metric
@@ -413,6 +431,7 @@ class AstraDBSemanticCache(BaseCache):
             metric=metric,
             ext_callers=ext_callers,
             component_name=COMPONENT_NAME_SEMANTICCACHE,
+            api_options=api_options,
         )
         self.collection = self.astra_env.collection
         self.async_collection = self.astra_env.async_collection

--- a/libs/astradb/langchain_astradb/chat_message_histories.py
+++ b/libs/astradb/langchain_astradb/chat_message_histories.py
@@ -22,6 +22,7 @@ from langchain_astradb.utils.astradb import (
 )
 
 if TYPE_CHECKING:
+    from astrapy.api_options import APIOptions
     from astrapy.authentication import TokenProvider
 
 DEFAULT_COLLECTION_NAME = "langchain_message_store"
@@ -40,6 +41,7 @@ class AstraDBChatMessageHistory(BaseChatMessageHistory):
         setup_mode: SetupMode = SetupMode.SYNC,
         pre_delete_collection: bool = False,
         ext_callers: list[tuple[str | None, str | None] | str | None] | None = None,
+        api_options: APIOptions | None = None,
     ) -> None:
         """Chat message history that stores history in Astra DB.
 
@@ -70,6 +72,13 @@ class AstraDBChatMessageHistory(BaseChatMessageHistory):
                 or just strings if no version info is provided, which, if supplied,
                 becomes the leading part of the User-Agent string in all API requests
                 related to this component.
+            api_options: an instance of ``astrapy.utils.api_options.APIOptions`` that
+                can be supplied to customize the interaction with the Data API
+                regarding serialization/deserialization, timeouts, custom headers
+                and so on. The provided options are applied on top of settings already
+                tailored to this library, and if specified will take precedence.
+                Passing None (default) means no customization is requested.
+                Refer to the astrapy documentation for details.
         """
         self.astra_env = _AstraDBCollectionEnvironment(
             collection_name=collection_name,
@@ -81,6 +90,7 @@ class AstraDBChatMessageHistory(BaseChatMessageHistory):
             pre_delete_collection=pre_delete_collection,
             ext_callers=ext_callers,
             component_name=COMPONENT_NAME_CHATMESSAGEHISTORY,
+            api_options=api_options,
         )
 
         self.collection = self.astra_env.collection

--- a/libs/astradb/langchain_astradb/document_loaders.py
+++ b/libs/astradb/langchain_astradb/document_loaders.py
@@ -24,6 +24,7 @@ from langchain_astradb.utils.astradb import (
 )
 
 if TYPE_CHECKING:
+    from astrapy.api_options import APIOptions
     from astrapy.authentication import TokenProvider
 
 logger = logging.getLogger(__name__)
@@ -47,6 +48,7 @@ class AstraDBLoader(BaseLoader):
         page_content_mapper: Callable[[dict], str] = json.dumps,
         metadata_mapper: Callable[[dict], dict[str, Any]] | None = None,
         ext_callers: list[tuple[str | None, str | None] | str | None] | None = None,
+        api_options: APIOptions | None = None,
     ) -> None:
         """Load DataStax Astra DB documents.
 
@@ -81,6 +83,13 @@ class AstraDBLoader(BaseLoader):
                 or just strings if no version info is provided, which, if supplied,
                 becomes the leading part of the User-Agent string in all API requests
                 related to this component.
+            api_options: an instance of ``astrapy.utils.api_options.APIOptions`` that
+                can be supplied to customize the interaction with the Data API
+                regarding serialization/deserialization, timeouts, custom headers
+                and so on. The provided options are applied on top of settings already
+                tailored to this library, and if specified will take precedence.
+                Passing None (default) means no customization is requested.
+                Refer to the astrapy documentation for details.
         """
         astra_db_env = _AstraDBCollectionEnvironment(
             collection_name=collection_name,
@@ -91,6 +100,7 @@ class AstraDBLoader(BaseLoader):
             setup_mode=SetupMode.OFF,
             ext_callers=ext_callers,
             component_name=COMPONENT_NAME_LOADER,
+            api_options=api_options,
         )
         self.astra_db_env = astra_db_env
         self.filter = filter_criteria

--- a/libs/astradb/langchain_astradb/storage.py
+++ b/libs/astradb/langchain_astradb/storage.py
@@ -30,6 +30,7 @@ from langchain_astradb.utils.astradb import (
 )
 
 if TYPE_CHECKING:
+    from astrapy.api_options import APIOptions
     from astrapy.authentication import TokenProvider
     from astrapy.results import CollectionUpdateResult
 
@@ -246,6 +247,7 @@ class AstraDBStore(AstraDBBaseStore[Any]):
         pre_delete_collection: bool = False,
         setup_mode: SetupMode = SetupMode.SYNC,
         ext_callers: list[tuple[str | None, str | None] | str | None] | None = None,
+        api_options: APIOptions | None = None,
     ) -> None:
         """BaseStore implementation using DataStax AstraDB as the underlying store.
 
@@ -286,6 +288,13 @@ class AstraDBStore(AstraDBBaseStore[Any]):
                 or just strings if no version info is provided, which, if supplied,
                 becomes the leading part of the User-Agent string in all API requests
                 related to this component.
+            api_options: an instance of ``astrapy.utils.api_options.APIOptions`` that
+                can be supplied to customize the interaction with the Data API
+                regarding serialization/deserialization, timeouts, custom headers
+                and so on. The provided options are applied on top of settings already
+                tailored to this library, and if specified will take precedence.
+                Passing None (default) means no customization is requested.
+                Refer to the astrapy documentation for details.
         """
         super().__init__(
             collection_name=collection_name,
@@ -297,6 +306,7 @@ class AstraDBStore(AstraDBBaseStore[Any]):
             pre_delete_collection=pre_delete_collection,
             ext_callers=ext_callers,
             component_name=COMPONENT_NAME_STORE,
+            api_options=api_options,
         )
 
     @override
@@ -320,6 +330,7 @@ class AstraDBByteStore(AstraDBBaseStore[bytes], ByteStore):
         pre_delete_collection: bool = False,
         setup_mode: SetupMode = SetupMode.SYNC,
         ext_callers: list[tuple[str | None, str | None] | str | None] | None = None,
+        api_options: APIOptions | None = None,
     ) -> None:
         """ByteStore implementation using DataStax AstraDB as the underlying store.
 
@@ -357,6 +368,13 @@ class AstraDBByteStore(AstraDBBaseStore[bytes], ByteStore):
                 or just strings if no version info is provided, which, if supplied,
                 becomes the leading part of the User-Agent string in all API requests
                 related to this component.
+            api_options: an instance of ``astrapy.utils.api_options.APIOptions`` that
+                can be supplied to customize the interaction with the Data API
+                regarding serialization/deserialization, timeouts, custom headers
+                and so on. The provided options are applied on top of settings already
+                tailored to this library, and if specified will take precedence.
+                Passing None (default) means no customization is requested.
+                Refer to the astrapy documentation for details.
         """
         super().__init__(
             collection_name=collection_name,
@@ -368,6 +386,7 @@ class AstraDBByteStore(AstraDBBaseStore[bytes], ByteStore):
             pre_delete_collection=pre_delete_collection,
             ext_callers=ext_callers,
             component_name=COMPONENT_NAME_BYTESTORE,
+            api_options=api_options,
         )
 
     @override

--- a/libs/astradb/langchain_astradb/utils/vector_store_codecs.py
+++ b/libs/astradb/langchain_astradb/utils/vector_store_codecs.py
@@ -305,7 +305,7 @@ class _AstraDBVectorStoreDocumentCodec(ABC):
         the resulting query would return Astra DB documents matching the metadata
         clause AND having an ID among those provided to this method. If, instead,
         an OR is required, one should run two separate queries and subsequently merge
-        the result (taking care of avoiding duplcates).
+        the result (taking care of avoiding duplicates).
 
         Args:
             ids: an iterable over Document IDs. If provided, the resulting Astra DB

--- a/libs/astradb/langchain_astradb/vectorstores.py
+++ b/libs/astradb/langchain_astradb/vectorstores.py
@@ -63,6 +63,7 @@ from langchain_astradb.utils.vector_store_codecs import (
 )
 
 if TYPE_CHECKING:
+    from astrapy.api_options import APIOptions
     from astrapy.authentication import (
         EmbeddingHeadersProvider,
         RerankingHeadersProvider,
@@ -104,7 +105,7 @@ class AstraDBQueryResult(NamedTuple):
     This class represents all that can be returned from the collection when running
     a query, which goes beyond just the corresponding Document.
 
-    Atributes:
+    Attributes:
         document: a ``langchain.schema.Document`` object representing the query result.
         id: the ID of the returned document.
         embedding: the embedding vector associated to the document. This may be None,
@@ -656,6 +657,7 @@ class AstraDBVectorStore(VectorStore):
         autodetect_collection: bool = False,
         ext_callers: list[tuple[str | None, str | None] | str | None] | None = None,
         component_name: str = COMPONENT_NAME_VECTORSTORE,
+        api_options: APIOptions | None = None,
         collection_rerank: CollectionRerankOptions | RerankServiceOptions | None = None,
         collection_reranking_api_key: str | RerankingHeadersProvider | None = None,
         collection_lexical: str
@@ -668,7 +670,7 @@ class AstraDBVectorStore(VectorStore):
         | dict[str, float]
         | HybridLimitFactorPrescription = None,
     ) -> None:
-        """A vector store wich uses DataStax Astra DB as backend.
+        """A vector store which uses DataStax Astra DB as backend.
 
         For more on Astra DB, visit
         https://docs.datastax.com/en/astra-db-serverless/index.html
@@ -772,6 +774,13 @@ class AstraDBVectorStore(VectorStore):
                 Defaults to "langchain_vectorstore", but can be overridden if this
                 component actually serves as the building block for another component
                 (such as when the vector store is used within a ``GraphRetriever``).
+            api_options: an instance of ``astrapy.utils.api_options.APIOptions`` that
+                can be supplied to customize the interaction with the Data API
+                regarding serialization/deserialization, timeouts, custom headers
+                and so on. The provided options are applied on top of settings already
+                tailored to this library, and if specified will take precedence.
+                Passing None (default) means no customization is requested.
+                Refer to the astrapy documentation for details.
             collection_rerank: providing reranking settings is necessary to run
                 hybrid searches for similarity. This parameter can be an instance
                 of the astrapy classes `CollectionRerankOptions` or
@@ -937,6 +946,7 @@ class AstraDBVectorStore(VectorStore):
                 environment=self.environment,
                 ext_callers=ext_callers,
                 component_name=component_name,
+                api_options=api_options,
             )
             if c_descriptor is None:
                 msg = f"Collection '{self.collection_name}' not found."
@@ -1018,6 +1028,7 @@ class AstraDBVectorStore(VectorStore):
             collection_embedding_api_key=self.collection_embedding_api_key,
             ext_callers=ext_callers,
             component_name=component_name,
+            api_options=api_options,
             collection_rerank=collection_rerank,
             collection_reranking_api_key=self.collection_reranking_api_key,
             collection_lexical=collection_lexical,


### PR DESCRIPTION
The introduction of an `api_options: APIOptions | None` parameter in all components introduces, in a non-breaking way, the possibility to tweak and customize all aspects of the interaction with the Data API, such as timeouts, preferred data types for reads, and so on.


Closes #125 