### PR TITLE
enable hybrid-specific tests in ordinary CI

### DIFF
--- a/libs/astradb/tests/integration_tests/test_vectorstore_autodetect.py
+++ b/libs/astradb/tests/integration_tests/test_vectorstore_autodetect.py
@@ -618,10 +618,6 @@ class TestAstraDBVectorStoreAutodetect:
             assert len(f_rec_warnings) == 1
         assert len(results_w_post) == 1
 
-    @pytest.mark.skipif(
-        "LANGCHAIN_TEST_HYBRID" not in os.environ,
-        reason="Hybrid tests not manually requested",
-    )
     @pytest.mark.parametrize(
         ("lexical_in_docs", "flat_md"),
         [
@@ -714,10 +710,6 @@ class TestAstraDBVectorStoreAutodetect:
         assert len(hits) == 2
         assert {doc.id for doc in hits} == {"doc0", "doc1"}
 
-    @pytest.mark.skipif(
-        "LANGCHAIN_TEST_HYBRID" not in os.environ,
-        reason="Hybrid tests not manually requested",
-    )
     @pytest.mark.parametrize(
         ("flat_md"),
         [(True), (False)],
@@ -795,10 +787,6 @@ class TestAstraDBVectorStoreAutodetect:
         assert len(hits) == 2
         assert {doc.id for doc in hits} == {"doc0", "doc1"}
 
-    @pytest.mark.skipif(
-        "LANGCHAIN_TEST_HYBRID" not in os.environ,
-        reason="Hybrid tests not manually requested",
-    )
     @pytest.mark.parametrize(
         ("lexical_in_docs", "flat_md"),
         [
@@ -892,10 +880,6 @@ class TestAstraDBVectorStoreAutodetect:
         assert len(hits) == 2
         assert {doc.id for doc in hits} == {"doc0", "doc1"}
 
-    @pytest.mark.skipif(
-        "LANGCHAIN_TEST_HYBRID" not in os.environ,
-        reason="Hybrid tests not manually requested",
-    )
     @pytest.mark.parametrize(
         ("flat_md"),
         [(True), (False)],

--- a/libs/astradb/tests/integration_tests/test_vectorstore_hybrid.py
+++ b/libs/astradb/tests/integration_tests/test_vectorstore_hybrid.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import os
 from typing import TYPE_CHECKING
 
 import pytest
@@ -112,10 +111,6 @@ def documents2_novectorize() -> list[Document]:
 
 @pytest.mark.skipif(
     not astra_db_env_vars_available(), reason="Missing Astra DB env. vars"
-)
-@pytest.mark.skipif(
-    "LANGCHAIN_TEST_HYBRID" not in os.environ,
-    reason="Hybrid tests not manually requested",
 )
 class TestAstraDBVectorStoreHybrid:
     def test_astradb_vectorstore_explicit_hybrid_lifecycle_vectorize_sync(


### PR DESCRIPTION
This PR removes the check on a env.var flag `LANGCHAIN_TEST_HYBRID` that used to gate running some specific hybrid-search-related tests.

With this PR those tests are run together with the rest in regular CI runs.
