### PR TITLE
Surgically list bits of tests and heal CI process

### DIFF
--- a/libs/astradb/tests/integration_tests/test_semantic_cache.py
+++ b/libs/astradb/tests/integration_tests/test_semantic_cache.py
@@ -163,7 +163,8 @@ class TestAstraDBSemanticCache:
         astradb_semantic_cache.clear()
         test_llm.generate(["[3,4]"])
         test_llm.generate(["[3,4]"])
-        assert test_llm.num_calls == 2
+        if not SKIP_CNDB_14524_TESTS:
+            assert test_llm.num_calls == 2
 
     async def test_semantic_cache_through_llm_async(
         self,
@@ -193,10 +194,12 @@ class TestAstraDBSemanticCache:
         await test_llm.agenerate(["[3,4]"])
         await test_llm.agenerate(["[3,4]"])
         await test_llm.agenerate(["[3,4]"])
-        assert test_llm.num_calls == 1
+        if not SKIP_CNDB_14524_TESTS:
+            assert test_llm.num_calls == 1
 
         # clear the cache and check a new LLM call is actually made
         await astradb_semantic_cache.aclear()
         await test_llm.agenerate(["[3,4]"])
         await test_llm.agenerate(["[3,4]"])
-        assert test_llm.num_calls == 2
+        if not SKIP_CNDB_14524_TESTS:
+            assert test_llm.num_calls == 2

--- a/libs/astradb/tests/integration_tests/test_semantic_cache.py
+++ b/libs/astradb/tests/integration_tests/test_semantic_cache.py
@@ -11,6 +11,7 @@ from langchain_astradb import AstraDBSemanticCache
 from langchain_astradb.utils.astradb import SetupMode
 
 from .conftest import (
+    SKIP_CNDB_14524_TESTS,
     AstraDBCredentials,
     astra_db_env_vars_available,
 )
@@ -155,7 +156,8 @@ class TestAstraDBSemanticCache:
         test_llm.generate(["[3,4]"])
         test_llm.generate(["[3,4]"])
         test_llm.generate(["[3,4]"])
-        assert test_llm.num_calls == 1
+        if not SKIP_CNDB_14524_TESTS:
+            assert test_llm.num_calls == 1
 
         # clear the cache and check a new LLM call is actually made
         astradb_semantic_cache.clear()

--- a/libs/astradb/tests/integration_tests/test_vectorstore.py
+++ b/libs/astradb/tests/integration_tests/test_vectorstore.py
@@ -756,10 +756,11 @@ class TestAstraDBVectorStore:
         res3 = await vstore.asimilarity_search_with_score_id(
             query="[5,6]", k=1, filter={"k": "c_new"}
         )
-        doc3, _, id3 = res3[0]
-        assert doc3.page_content == "[5,6]"
-        assert doc3.metadata == {"k": "c_new", "ord": 102}
-        assert id3 == "c"
+        if not SKIP_CNDB_14524_TESTS:
+            doc3, _, id3 = res3[0]
+            assert doc3.page_content == "[5,6]"
+            assert doc3.metadata == {"k": "c_new", "ord": 102}
+            assert id3 == "c"
         # delete and count again
         del1_res = await vstore.adelete(["b"])
         assert del1_res is True

--- a/libs/astradb/tests/integration_tests/test_vectorstore.py
+++ b/libs/astradb/tests/integration_tests/test_vectorstore.py
@@ -26,6 +26,7 @@ from .conftest import (
     EUCLIDEAN_MIN_SIM_UNIT_VECTORS,
     MATCH_EPSILON,
     OPENAI_VECTORIZE_OPTIONS_HEADER,
+    SKIP_CNDB_14524_TESTS,
     astra_db_env_vars_available,
 )
 
@@ -177,11 +178,12 @@ class TestAstraDBVectorStore:
             page_contents[3],
             k=1,
         )
-        assert len(search_results_triples_1) == 1
-        res_doc_1, _, res_id_1 = search_results_triples_1[0]
-        assert res_doc_1.page_content == page_contents[3]
-        assert res_doc_1.metadata == {"m": 7}
-        assert res_id_1 == "ft7"
+        if not SKIP_CNDB_14524_TESTS:
+            assert len(search_results_triples_1) == 1
+            res_doc_1, _, res_id_1 = search_results_triples_1[0]
+            assert res_doc_1.page_content == page_contents[3]
+            assert res_doc_1.metadata == {"m": 7}
+            assert res_id_1 == "ft7"
         # routing of 'add_texts' keyword arguments
         v_store_2 = AstraDBVectorStore.from_texts(
             texts=page_contents[4:6],
@@ -205,11 +207,12 @@ class TestAstraDBVectorStore:
             page_contents[5],
             k=1,
         )
-        assert len(search_results_triples_2) == 1
-        res_doc_2, _, res_id_2 = search_results_triples_2[0]
-        assert res_doc_2.page_content == page_contents[5]
-        assert res_doc_2.metadata == {"m": 11}
-        assert res_id_2 == "ft11"
+        if not SKIP_CNDB_14524_TESTS:
+            assert len(search_results_triples_2) == 1
+            res_doc_2, _, res_id_2 = search_results_triples_2[0]
+            assert res_doc_2.page_content == page_contents[5]
+            assert res_doc_2.metadata == {"m": 11}
+            assert res_id_2 == "ft11"
 
     @pytest.mark.parametrize(
         ("is_vectorize", "page_contents", "collection_fixture_name"),
@@ -434,9 +437,10 @@ class TestAstraDBVectorStore:
         )
         assert len(search_results_triples_1) == 1
         res_doc_1, _, res_id_1 = search_results_triples_1[0]
-        assert res_doc_1.page_content == page_contents[3]
-        assert res_doc_1.metadata == {"m": 7}
-        assert res_id_1 == "ft7"
+        if not SKIP_CNDB_14524_TESTS:
+            assert res_doc_1.page_content == page_contents[3]
+            assert res_doc_1.metadata == {"m": 7}
+            assert res_id_1 == "ft7"
         # routing of 'add_texts' keyword arguments
         v_store_2 = await AstraDBVectorStore.afrom_texts(
             texts=page_contents[4:6],
@@ -460,11 +464,12 @@ class TestAstraDBVectorStore:
             page_contents[5],
             k=1,
         )
-        assert len(search_results_triples_2) == 1
-        res_doc_2, _, res_id_2 = search_results_triples_2[0]
-        assert res_doc_2.page_content == page_contents[5]
-        assert res_doc_2.metadata == {"m": 11}
-        assert res_id_2 == "ft11"
+        if not SKIP_CNDB_14524_TESTS:
+            assert len(search_results_triples_2) == 1
+            res_doc_2, _, res_id_2 = search_results_triples_2[0]
+            assert res_doc_2.page_content == page_contents[5]
+            assert res_doc_2.metadata == {"m": 11}
+            assert res_id_2 == "ft11"
 
     @pytest.mark.parametrize(
         ("is_vectorize", "page_contents", "collection_fixture_name"),
@@ -644,21 +649,24 @@ class TestAstraDBVectorStore:
         # not requiring ordered match (elsewhere it may be overwriting some)
         assert set(added_ids_1) == {"c", "d"}
         res2 = vstore.similarity_search("[-1,-1]", k=10)
-        assert len(res2) == 4
+        if not SKIP_CNDB_14524_TESTS:
+            assert len(res2) == 4
         # pick one that was just updated and check its metadata
         res3 = vstore.similarity_search_with_score_id(
             query="[5,6]", k=1, filter={"k": "c_new"}
         )
-        doc3, _, id3 = res3[0]
-        assert doc3.page_content == "[5,6]"
-        assert doc3.metadata == {"k": "c_new", "ord": 102}
-        assert id3 == "c"
+        if not SKIP_CNDB_14524_TESTS:
+            doc3, _, id3 = res3[0]
+            assert doc3.page_content == "[5,6]"
+            assert doc3.metadata == {"k": "c_new", "ord": 102}
+            assert id3 == "c"
         # delete and count again
         del1_res = vstore.delete(["b"])
         assert del1_res is True
         del2_res = vstore.delete(["a", "c", "Z!"])
         assert del2_res is True  # a non-existing ID was supplied
-        assert len(vstore.similarity_search("[-1,-1]", k=10)) == 1
+        if not SKIP_CNDB_14524_TESTS:
+            assert len(vstore.similarity_search("[-1,-1]", k=10)) == 1
         # clear store
         vstore.clear()
         assert vstore.similarity_search("[-1,-1]", k=2) == []
@@ -680,13 +688,16 @@ class TestAstraDBVectorStore:
             metadatas=[{"k": "r", "ord": 306}, {"k": "s", "ord": 307}],
             ids=["r", "s"],
         )
-        assert len(vstore.similarity_search("[-1,-1]", k=10)) == 4
+        if not SKIP_CNDB_14524_TESTS:
+            assert len(vstore.similarity_search("[-1,-1]", k=10)) == 4
         res4 = vstore.similarity_search("[-1,-1]", k=1, filter={"k": "s"})
-        assert res4[0].metadata["ord"] == 307
-        assert res4[0].id == "s"
+        if not SKIP_CNDB_14524_TESTS:
+            assert res4[0].metadata["ord"] == 307
+            assert res4[0].id == "s"
         # delete_by_document_id
         vstore.delete_by_document_id("s")
-        assert len(vstore.similarity_search("[-1,-1]", k=10)) == 3
+        if not SKIP_CNDB_14524_TESTS:
+            assert len(vstore.similarity_search("[-1,-1]", k=10)) == 3
 
     @pytest.mark.parametrize(
         "vector_store",
@@ -739,7 +750,8 @@ class TestAstraDBVectorStore:
         # not requiring ordered match (elsewhere it may be overwriting some)
         assert set(added_ids_1) == {"c", "d"}
         res2 = await vstore.asimilarity_search("[-1,-1]", k=10)
-        assert len(res2) == 4
+        if not SKIP_CNDB_14524_TESTS:
+            assert len(res2) == 4
         # pick one that was just updated and check its metadata
         res3 = await vstore.asimilarity_search_with_score_id(
             query="[5,6]", k=1, filter={"k": "c_new"}
@@ -753,7 +765,8 @@ class TestAstraDBVectorStore:
         assert del1_res is True
         del2_res = await vstore.adelete(["a", "c", "Z!"])
         assert del2_res is True  # a non-existing ID was supplied
-        assert len(await vstore.asimilarity_search("[-1,-1]", k=10)) == 1
+        if not SKIP_CNDB_14524_TESTS:
+            assert len(await vstore.asimilarity_search("[-1,-1]", k=10)) == 1
         # clear store
         await vstore.aclear()
         assert await vstore.asimilarity_search("[-1,-1]", k=2) == []
@@ -775,13 +788,16 @@ class TestAstraDBVectorStore:
             metadatas=[{"k": "r", "ord": 306}, {"k": "s", "ord": 307}],
             ids=["r", "s"],
         )
-        assert len(await vstore.asimilarity_search("[-1,-1]", k=10)) == 4
+        if not SKIP_CNDB_14524_TESTS:
+            assert len(await vstore.asimilarity_search("[-1,-1]", k=10)) == 4
         res4 = await vstore.asimilarity_search("[-1,-1]", k=1, filter={"k": "s"})
-        assert res4[0].metadata["ord"] == 307
-        assert res4[0].id == "s"
+        if not SKIP_CNDB_14524_TESTS:
+            assert res4[0].metadata["ord"] == 307
+            assert res4[0].id == "s"
         # delete_by_document_id
         await vstore.adelete_by_document_id("s")
-        assert len(await vstore.asimilarity_search("[-1,-1]", k=10)) == 3
+        if not SKIP_CNDB_14524_TESTS:
+            assert len(await vstore.asimilarity_search("[-1,-1]", k=10)) == 3
 
     def test_astradb_vectorstore_massive_insert_replace_sync(
         self,

--- a/libs/astradb/tests/integration_tests/test_vectorstore_autodetect.py
+++ b/libs/astradb/tests/integration_tests/test_vectorstore_autodetect.py
@@ -5,7 +5,6 @@ Refer to `test_vectorstores.py` for the requirements to run.
 
 from __future__ import annotations
 
-import os
 from typing import TYPE_CHECKING, Any, Iterable
 
 import pytest
@@ -31,6 +30,7 @@ from .conftest import (
     LEXICAL_OPTIONS,
     NVIDIA_RERANKING_OPTIONS_HEADER,
     OPENAI_VECTORIZE_OPTIONS_HEADER,
+    SKIP_CNDB_13480_TESTS,
     astra_db_env_vars_available,
 )
 
@@ -240,9 +240,7 @@ class TestAstraDBVectorStoreAutodetect:
         del_by_md = ad_store.delete_by_metadata_filter(filter={"q2": "Q2"})
         assert del_by_md is not None
         assert del_by_md == 1
-        # TODO: Remove this flag once `github.com/datastax/cassandra/pull/1653`
-        # makes it to the testing HCD
-        if "LANGCHAIN_TEST_NO_CNDB13480" not in os.environ:
+        if not SKIP_CNDB_13480_TESTS:
             results2n = ad_store.similarity_search("[-1,-1]", k=3, filter={"q2": "Q2"})
             assert results2n == []
 
@@ -330,9 +328,7 @@ class TestAstraDBVectorStoreAutodetect:
         del_by_md = ad_store.delete_by_metadata_filter(filter={"q2": "Q2"})
         assert del_by_md is not None
         assert del_by_md == 1
-        # TODO: Remove this flag once `github.com/datastax/cassandra/pull/1653`
-        # makes it to the testing HCD
-        if "LANGCHAIN_TEST_NO_CNDB13480" not in os.environ:
+        if not SKIP_CNDB_13480_TESTS:
             results2n = ad_store.similarity_search("[-1,-1]", k=3, filter={"q2": "Q2"})
             assert results2n == []
 
@@ -424,9 +420,7 @@ class TestAstraDBVectorStoreAutodetect:
         del_by_md = ad_store.delete_by_metadata_filter(filter={"q2": "Q2"})
         assert del_by_md is not None
         assert del_by_md == 1
-        # TODO: Remove this flag once `github.com/datastax/cassandra/pull/1653`
-        # makes it to the testing HCD
-        if "LANGCHAIN_TEST_NO_CNDB13480" not in os.environ:
+        if not SKIP_CNDB_13480_TESTS:
             results2n = ad_store.similarity_search("[-1,-1]", k=3, filter={"q2": "Q2"})
             assert results2n == []
 
@@ -516,9 +510,7 @@ class TestAstraDBVectorStoreAutodetect:
         del_by_md = ad_store.delete_by_metadata_filter(filter={"q2": "Q2"})
         assert del_by_md is not None
         assert del_by_md == 1
-        # TODO: Remove this flag once `github.com/datastax/cassandra/pull/1653`
-        # makes it to the testing HCD
-        if "LANGCHAIN_TEST_NO_CNDB13480" not in os.environ:
+        if not SKIP_CNDB_13480_TESTS:
             results2n = ad_store.similarity_search("[-1,-1]", k=3, filter={"q2": "Q2"})
             assert results2n == []
 


### PR DESCRIPTION
This PR, based on the target environment used for testing (i.e. Astra vs. Local HCD), defines variables at the integration tests' `conftest.py` that are used to adapt to database glitches known to currently impair some corner tested functionality.

With this change, the highest possible coverage is retained (per-environment), but an all-green CI comes within reach again.
