### PR TITLE
Vectorstore, get_by_ids

### DIFF
--- a/libs/astradb/langchain_astradb/utils/astradb.py
+++ b/libs/astradb/langchain_astradb/utils/astradb.py
@@ -74,6 +74,10 @@ MAX_CONCURRENT_DOCUMENT_INSERTIONS = 20
 MAX_CONCURRENT_DOCUMENT_REPLACEMENTS = 20
 # Thread/coroutine count for one-doc-at-a-time deletes:
 MAX_CONCURRENT_DOCUMENT_DELETIONS = 20
+# Size of each chunk of document IDs for get_by_ids
+DEFAULT_ID_LIST_SIZE = 80
+# Thread/coroutine count for concurrent requests for get_by_ids
+MAX_CONCURRENT_GET_BY_IDS_REQUESTS = 20
 
 # Hardcoded here for the time being
 ASTRA_DB_REQUEST_TIMEOUT_MS = 30000

--- a/libs/astradb/langchain_astradb/vectorstores.py
+++ b/libs/astradb/langchain_astradb/vectorstores.py
@@ -1452,11 +1452,14 @@ class AstraDBVectorStore(VectorStore):
         self,
         texts: Iterable[str],
         embedding_vectors: Sequence[list[float] | None],
-        metadatas: list[dict] | None = None,
-        ids: list[str] | None = None,
+        metadatas: list[dict[str, Any]] | None = None,
+        ids: list[str | None] | None = None,
     ) -> list[DocDict]:
+        ids1: list[str]
         if ids is None:
-            ids = [uuid.uuid4().hex for _ in texts]
+            ids1 = [uuid.uuid4().hex for _ in texts]
+        else:
+            ids1 = [uuid.uuid4().hex if id_ is None else id_ for id_ in ids]
         if metadatas is None:
             metadatas = [{} for _ in texts]
         documents_to_insert = [
@@ -1469,7 +1472,7 @@ class AstraDBVectorStore(VectorStore):
             for b_txt, b_emb, b_id, b_md in zip(
                 texts,
                 embedding_vectors,
-                ids,
+                ids1,
                 metadatas,
                 strict=True,
             )
@@ -1484,7 +1487,7 @@ class AstraDBVectorStore(VectorStore):
     def add_texts(
         self,
         texts: Iterable[str],
-        metadatas: list[dict] | None = None,
+        metadatas: list[dict[str, Any]] | None = None,
         ids: list[str] | None = None,
         *,
         batch_size: int | None = None,
@@ -1537,7 +1540,7 @@ class AstraDBVectorStore(VectorStore):
         else:
             embedding_vectors = self._get_safe_embedding().embed_documents(list(texts))
         documents_to_insert = self._get_documents_to_insert(
-            texts, embedding_vectors, metadatas, ids
+            texts, embedding_vectors, metadatas, cast("list[str | None]", ids)
         )
 
         # perform an AstraPy insert_many, catching exceptions for overwriting docs
@@ -1680,7 +1683,7 @@ class AstraDBVectorStore(VectorStore):
                 list(texts)
             )
         documents_to_insert = self._get_documents_to_insert(
-            texts, embedding_vectors, metadatas, ids
+            texts, embedding_vectors, metadatas, cast("list[str | None]", ids)
         )
 
         # perform an AstraPy insert_many, catching exceptions for overwriting docs

--- a/libs/astradb/langchain_astradb/vectorstores.py
+++ b/libs/astradb/langchain_astradb/vectorstores.py
@@ -33,9 +33,11 @@ from typing_extensions import override
 from langchain_astradb.utils.astradb import (
     COMPONENT_NAME_VECTORSTORE,
     DEFAULT_DOCUMENT_CHUNK_SIZE,
+    DEFAULT_ID_LIST_SIZE,
     MAX_CONCURRENT_DOCUMENT_DELETIONS,
     MAX_CONCURRENT_DOCUMENT_INSERTIONS,
     MAX_CONCURRENT_DOCUMENT_REPLACEMENTS,
+    MAX_CONCURRENT_GET_BY_IDS_REQUESTS,
     HybridSearchMode,
     SetupMode,
     _AstraDBCollectionEnvironment,
@@ -2523,6 +2525,61 @@ class AstraDBVectorStore(VectorStore):
             return hits[0]
 
         return None
+
+    @override
+    def get_by_ids(
+        self,
+        ids: Sequence[str],
+        /,
+        batch_size: int | None = None,
+        batch_concurrency: int | None = None,
+    ) -> list[Document]:
+        """Get documents by their IDs.
+
+        The returned documents have the ID field set to the ID of the
+        document in the vector store.
+
+        Fewer documents may be returned than requested if some IDs are not found or
+        if there are duplicated IDs.
+
+        Users should not assume that the order of the returned documents matches
+        the order of the input IDs. Instead, users should rely on the ID field of the
+        returned documents.
+
+        Args:
+            ids: List of ids to retrieve.
+            batch_size: If many IDs are requested, these are split in chunks and
+                multiple requests are run and collated. This sets the size of each
+                such chunk of IDs.
+                Default is 80. The database sets a hard limit of 100.
+            batch_concurrency: Number of threads for executing multiple requests
+                if needed. Default is 20.
+
+        Returns:
+            List of Documents.
+        """
+        batch_size_ = batch_size or DEFAULT_ID_LIST_SIZE
+        batch_concurrency_ = batch_concurrency or MAX_CONCURRENT_GET_BY_IDS_REQUESTS
+        id_list1 = list(set(ids))
+        num_chunks = 1 + (len(id_list1) - 1) // batch_size_
+        id_chunks = [
+            id_list1[batch_size_ * chunk_id : batch_size_ * (chunk_id + 1)]
+            for chunk_id in range(num_chunks)
+        ]
+
+        def query_for_ids(id_chunk: list[str]) -> Iterable[AstraDBQueryResult]:
+            return self.run_query(n=batch_size_, ids=id_chunk)
+
+        with ThreadPoolExecutor(max_workers=batch_concurrency_) as executor:
+            hit_lists = executor.map(
+                query_for_ids,
+                id_chunks,
+            )
+        return [doc for hit_list in hit_lists for doc, _, _, _ in hit_list]
+
+    # TODO: aget
+    # @override
+    # async def aget_by_ids(self, ids: Sequence[str], /) -> list[Document]:
 
     @override
     def similarity_search(

--- a/libs/astradb/langchain_astradb/vectorstores.py
+++ b/libs/astradb/langchain_astradb/vectorstores.py
@@ -2580,6 +2580,43 @@ class AstraDBVectorStore(VectorStore):
             )
         return [doc for hit_list in hit_lists for doc, _, _, _ in hit_list]
 
+    def get_by_document_ids(
+        self,
+        ids: Sequence[str],
+        /,
+        batch_size: int | None = None,
+        batch_concurrency: int | None = None,
+    ) -> list[Document]:
+        """Get documents by their IDs.
+
+        The returned documents have the ID field set to the ID of the
+        document in the vector store.
+
+        Fewer documents may be returned than requested if some IDs are not found or
+        if there are duplicated IDs.
+
+        Users should not assume that the order of the returned documents matches
+        the order of the input IDs. Instead, users should rely on the ID field of the
+        returned documents.
+
+        Args:
+            ids: List of ids to retrieve.
+            batch_size: If many IDs are requested, these are split in chunks and
+                multiple requests are run and collated. This sets the size of each
+                such chunk of IDs.
+                Default is 80. The database sets a hard limit of 100.
+            batch_concurrency: Number of threads for executing multiple requests
+                if needed. Default is 20.
+
+        Returns:
+            List of Documents.
+        """
+        return self.get_by_ids(
+            ids,
+            batch_size=batch_size,
+            batch_concurrency=batch_concurrency,
+        )
+
     @override
     async def aget_by_ids(
         self,
@@ -2632,6 +2669,43 @@ class AstraDBVectorStore(VectorStore):
         tasks = [asyncio.create_task(query_for_ids(id_chunk)) for id_chunk in id_chunks]
         hit_lists = await asyncio.gather(*tasks, return_exceptions=False)
         return [doc for hit_list in hit_lists async for doc, _, _, _ in hit_list]
+
+    async def aget_by_document_ids(
+        self,
+        ids: Sequence[str],
+        /,
+        batch_size: int | None = None,
+        batch_concurrency: int | None = None,
+    ) -> list[Document]:
+        """Get documents by their IDs.
+
+        The returned documents have the ID field set to the ID of the
+        document in the vector store.
+
+        Fewer documents may be returned than requested if some IDs are not found or
+        if there are duplicated IDs.
+
+        Users should not assume that the order of the returned documents matches
+        the order of the input IDs. Instead, users should rely on the ID field of the
+        returned documents.
+
+        Args:
+            ids: List of ids to retrieve.
+            batch_size: If many IDs are requested, these are split in chunks and
+                multiple requests are run and collated. This sets the size of each
+                such chunk of IDs.
+                Default is 80. The database sets a hard limit of 100.
+            batch_concurrency: Number of threads for executing multiple requests
+                if needed. Default is 20.
+
+        Returns:
+            List of Documents.
+        """
+        return await self.aget_by_ids(
+            ids,
+            batch_size=batch_size,
+            batch_concurrency=batch_concurrency,
+        )
 
     @override
     def similarity_search(

--- a/libs/astradb/tests/integration_tests/standard_tests/test_vectorstore.py
+++ b/libs/astradb/tests/integration_tests/standard_tests/test_vectorstore.py
@@ -12,8 +12,6 @@ from tests.integration_tests.conftest import (
     astra_db_env_vars_available,
 )
 
-GET_BY_IDS_NOT_SUPPORTED_MESSAGE = "AstraDBVectorStore doesn't support get_by_ids."
-
 
 @pytest.mark.skipif(
     not astra_db_env_vars_available(), reason="Missing Astra DB env. vars"
@@ -38,39 +36,3 @@ class TestAstraDBVectorStoreIntegration(VectorStoreIntegrationTests):
     @pytest.fixture
     def vectorstore(self) -> VectorStore:
         return self._vectorstore
-
-    @pytest.mark.xfail(reason=GET_BY_IDS_NOT_SUPPORTED_MESSAGE)
-    def test_get_by_ids(self, vectorstore: VectorStore) -> None:
-        pass
-
-    @pytest.mark.xfail(reason=GET_BY_IDS_NOT_SUPPORTED_MESSAGE)
-    def test_get_by_ids_missing(self, vectorstore: VectorStore) -> None:
-        pass
-
-    @pytest.mark.xfail(reason=GET_BY_IDS_NOT_SUPPORTED_MESSAGE)
-    def test_add_documents_documents(self, vectorstore: VectorStore) -> None:
-        pass
-
-    @pytest.mark.xfail(reason=GET_BY_IDS_NOT_SUPPORTED_MESSAGE)
-    def test_add_documents_with_existing_ids(self, vectorstore: VectorStore) -> None:
-        pass
-
-    @pytest.mark.xfail(reason=GET_BY_IDS_NOT_SUPPORTED_MESSAGE)
-    async def test_get_by_ids_async(self, vectorstore: VectorStore) -> None:
-        pass
-
-    @pytest.mark.xfail(reason=GET_BY_IDS_NOT_SUPPORTED_MESSAGE)
-    async def test_get_by_ids_missing_async(self, vectorstore: VectorStore) -> None:
-        pass
-
-    @pytest.mark.xfail(reason=GET_BY_IDS_NOT_SUPPORTED_MESSAGE)
-    async def test_add_documents_documents_async(
-        self, vectorstore: VectorStore
-    ) -> None:
-        pass
-
-    @pytest.mark.xfail(reason=GET_BY_IDS_NOT_SUPPORTED_MESSAGE)
-    async def test_add_documents_with_existing_ids_async(
-        self, vectorstore: VectorStore
-    ) -> None:
-        pass

--- a/libs/astradb/tests/integration_tests/standard_tests/test_vectorstore.py
+++ b/libs/astradb/tests/integration_tests/standard_tests/test_vectorstore.py
@@ -12,6 +12,10 @@ from tests.integration_tests.conftest import (
     astra_db_env_vars_available,
 )
 
+TEST_EXPECTS_DEFINITE_DOCUMENT_ORDERING = (
+    "Currently a specific document ordering is expected."
+)
+
 
 @pytest.mark.skipif(
     not astra_db_env_vars_available(), reason="Missing Astra DB env. vars"
@@ -36,3 +40,31 @@ class TestAstraDBVectorStoreIntegration(VectorStoreIntegrationTests):
     @pytest.fixture
     def vectorstore(self) -> VectorStore:
         return self._vectorstore
+
+    @pytest.mark.xfail(reason=TEST_EXPECTS_DEFINITE_DOCUMENT_ORDERING)
+    def test_add_documents_with_existing_ids(self, vectorstore: VectorStore) -> None:
+        pass
+
+    @pytest.mark.xfail(reason=TEST_EXPECTS_DEFINITE_DOCUMENT_ORDERING)
+    async def test_add_documents_with_existing_ids_async(
+        self, vectorstore: VectorStore
+    ) -> None:
+        pass
+
+    @pytest.mark.xfail(reason=TEST_EXPECTS_DEFINITE_DOCUMENT_ORDERING)
+    def test_get_by_ids(self, vectorstore: VectorStore) -> None:
+        pass
+
+    @pytest.mark.xfail(reason=TEST_EXPECTS_DEFINITE_DOCUMENT_ORDERING)
+    async def test_get_by_ids_async(self, vectorstore: VectorStore) -> None:
+        pass
+
+    @pytest.mark.xfail(reason=TEST_EXPECTS_DEFINITE_DOCUMENT_ORDERING)
+    def test_add_documents_documents(self, vectorstore: VectorStore) -> None:
+        pass
+
+    @pytest.mark.xfail(reason=TEST_EXPECTS_DEFINITE_DOCUMENT_ORDERING)
+    async def test_add_documents_documents_async(
+        self, vectorstore: VectorStore
+    ) -> None:
+        pass

--- a/libs/astradb/tests/integration_tests/test_vectorstore.py
+++ b/libs/astradb/tests/integration_tests/test_vectorstore.py
@@ -1442,6 +1442,65 @@ class TestAstraDBVectorStore:
         with pytest.raises(ValueError, match="must be greater than 0"):
             vstore.get_by_ids([], batch_concurrency=-1)
 
+    async def test_astradb_vectorstore_get_by_ids_async(
+        self,
+        vector_store_d2: AstraDBVectorStore,
+    ) -> None:
+        """Get by (multiple) document ids"""
+        vstore = vector_store_d2
+        docs = [Document(id=f"doc_{i:03}", page_content=f"[0,{i}]") for i in range(250)]
+        doc_ids = {doc.id or "" for doc in docs}
+        await vstore.aadd_documents(docs)
+
+        # empty id list
+        assert await vstore.aget_by_ids([]) == []
+        # small id list
+        exp_ids0 = [f"doc_{i:03}" for i in range(10)]
+        ids0 = {doc.id or "" for doc in await vstore.aget_by_ids(exp_ids0)}
+        assert sorted(exp_ids0) == sorted(ids0)
+        # long id list
+        exp_ids1 = [f"doc_{i:03}" for i in range(10, 220)]
+        ids1 = [doc.id or "" for doc in await vstore.aget_by_ids(exp_ids1)]
+        assert sorted(exp_ids1) == sorted(ids1)
+        # including non-found ids
+        qry_ids2 = [f"doc_{i:03}" for i in range(110, 350)]
+        exp_ids2 = list(doc_ids & set(qry_ids2))
+        ids2 = [doc.id or "" for doc in await vstore.aget_by_ids(exp_ids2)]
+        assert sorted(exp_ids2) == sorted(ids2)
+        # repeated ids
+        exp_ids3 = [f"doc_{i:03}" for i in range(50, 75)]
+        ids3 = {doc.id or "" for doc in await vstore.aget_by_ids(exp_ids3 + exp_ids3)}
+        assert sorted(exp_ids3) == sorted(ids3)
+        # passing a tuple
+        exp_ids4 = ("doc_019", "doc_002", "doc_174", "doc_159", "doc_041")
+        ids4 = {doc.id or "" for doc in await vstore.aget_by_ids(exp_ids4)}
+        assert sorted(exp_ids4) == sorted(ids4)
+        # customized batch/concurrency 1
+        exp_ids5 = [f"doc_{i:03}" for i in range(20)]
+        ids5 = {
+            doc.id or ""
+            for doc in await vstore.aget_by_ids(
+                exp_ids5,
+                batch_size=4,
+                batch_concurrency=2,
+            )
+        }
+        assert sorted(exp_ids5) == sorted(ids5)
+        # customized batch/concurrency 2 (with remainder)
+        exp_ids6 = [f"doc_{i:03}" for i in range(20)]
+        ids6 = {
+            doc.id or ""
+            for doc in await vstore.aget_by_ids(
+                exp_ids6,
+                batch_size=7,
+                batch_concurrency=5,
+            )
+        }
+        assert sorted(exp_ids6) == sorted(ids6)
+        # unacceptable batch/concurrency parameters
+        with pytest.raises(ValueError, match="initial value must be"):
+            await vstore.aget_by_ids([], batch_concurrency=-1)
+
     @pytest.mark.parametrize(
         ("is_vectorize", "vector_store", "texts", "query"),
         [

--- a/libs/astradb/tests/integration_tests/test_vectorstore.py
+++ b/libs/astradb/tests/integration_tests/test_vectorstore.py
@@ -1383,6 +1383,65 @@ class TestAstraDBVectorStore:
         assert valid.metadata["group"] == "consonant"
         assert valid.metadata["letter"] == "q"
 
+    def test_astradb_vectorstore_get_by_ids_sync(
+        self,
+        vector_store_d2: AstraDBVectorStore,
+    ) -> None:
+        """Get by (multiple) document ids"""
+        vstore = vector_store_d2
+        docs = [Document(id=f"doc_{i:03}", page_content=f"[0,{i}]") for i in range(250)]
+        doc_ids = {doc.id or "" for doc in docs}
+        vstore.add_documents(docs)
+
+        # empty id list
+        assert vstore.get_by_ids([]) == []
+        # small id list
+        exp_ids0 = [f"doc_{i:03}" for i in range(10)]
+        ids0 = {doc.id or "" for doc in vstore.get_by_ids(exp_ids0)}
+        assert sorted(exp_ids0) == sorted(ids0)
+        # long id list
+        exp_ids1 = [f"doc_{i:03}" for i in range(10, 220)]
+        ids1 = [doc.id or "" for doc in vstore.get_by_ids(exp_ids1)]
+        assert sorted(exp_ids1) == sorted(ids1)
+        # including non-found ids
+        qry_ids2 = [f"doc_{i:03}" for i in range(110, 350)]
+        exp_ids2 = list(doc_ids & set(qry_ids2))
+        ids2 = [doc.id or "" for doc in vstore.get_by_ids(exp_ids2)]
+        assert sorted(exp_ids2) == sorted(ids2)
+        # repeated ids
+        exp_ids3 = [f"doc_{i:03}" for i in range(50, 75)]
+        ids3 = {doc.id or "" for doc in vstore.get_by_ids(exp_ids3 + exp_ids3)}
+        assert sorted(exp_ids3) == sorted(ids3)
+        # passing a tuple
+        exp_ids4 = ("doc_019", "doc_002", "doc_174", "doc_159", "doc_041")
+        ids4 = {doc.id or "" for doc in vstore.get_by_ids(exp_ids4)}
+        assert sorted(exp_ids4) == sorted(ids4)
+        # customized batch/concurrency 1
+        exp_ids5 = [f"doc_{i:03}" for i in range(20)]
+        ids5 = {
+            doc.id or ""
+            for doc in vstore.get_by_ids(
+                exp_ids5,
+                batch_size=4,
+                batch_concurrency=2,
+            )
+        }
+        assert sorted(exp_ids5) == sorted(ids5)
+        # customized batch/concurrency 2 (with remainder)
+        exp_ids6 = [f"doc_{i:03}" for i in range(20)]
+        ids6 = {
+            doc.id or ""
+            for doc in vstore.get_by_ids(
+                exp_ids6,
+                batch_size=7,
+                batch_concurrency=5,
+            )
+        }
+        assert sorted(exp_ids6) == sorted(ids6)
+        # unacceptable batch/concurrency parameters
+        with pytest.raises(ValueError, match="must be greater than 0"):
+            vstore.get_by_ids([], batch_concurrency=-1)
+
     @pytest.mark.parametrize(
         ("is_vectorize", "vector_store", "texts", "query"),
         [

--- a/libs/astradb/tests/integration_tests/test_vectorstore.py
+++ b/libs/astradb/tests/integration_tests/test_vectorstore.py
@@ -1403,6 +1403,10 @@ class TestAstraDBVectorStore:
         exp_ids1 = [f"doc_{i:03}" for i in range(10, 220)]
         ids1 = [doc.id or "" for doc in vstore.get_by_ids(exp_ids1)]
         assert sorted(exp_ids1) == sorted(ids1)
+        # long-name alias
+        exp_ids1l = [f"doc_{i:03}" for i in range(10, 220)]
+        ids1l = [doc.id or "" for doc in vstore.get_by_document_ids(exp_ids1l)]
+        assert sorted(exp_ids1l) == sorted(ids1l)
         # including non-found ids
         qry_ids2 = [f"doc_{i:03}" for i in range(110, 350)]
         exp_ids2 = list(doc_ids & set(qry_ids2))
@@ -1462,6 +1466,10 @@ class TestAstraDBVectorStore:
         exp_ids1 = [f"doc_{i:03}" for i in range(10, 220)]
         ids1 = [doc.id or "" for doc in await vstore.aget_by_ids(exp_ids1)]
         assert sorted(exp_ids1) == sorted(ids1)
+        # long-name alias
+        exp_ids1l = [f"doc_{i:03}" for i in range(10, 220)]
+        ids1l = [doc.id or "" for doc in await vstore.aget_by_document_ids(exp_ids1l)]
+        assert sorted(exp_ids1l) == sorted(ids1l)
         # including non-found ids
         qry_ids2 = [f"doc_{i:03}" for i in range(110, 350)]
         exp_ids2 = list(doc_ids & set(qry_ids2))


### PR DESCRIPTION
Closes #150 

Note: a bug gets fixed along the way with this PR, namely the behaviour of [a]add_texts when the `ids` list is a mixture of strings and `None`. (currently the encoder would refrain from encoding documents with a null ID; and even if it did, the unique_list utility could discard documents if multiple with id of None are passed).
